### PR TITLE
feat: add refract schema bootstrap

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,6 +12,8 @@ libreferee_la_SOURCES = \
    referee/referee.cc \
    services/service.h \
    services/service.cc \
+   refract/bootstrap.h \
+   refract/bootstrap.cc \
    refract/schema_registry.h \
    refract/schema_registry.cc \
    referee_sqlite/sqlite_store.h \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -141,6 +141,7 @@ libreferee_la_DEPENDENCIES = $(am__DEPENDENCIES_1)
 am__dirstamp = $(am__leading_dot)dirstamp
 am_libreferee_la_OBJECTS = referee/libreferee_la-referee.lo \
 	services/libreferee_la-service.lo \
+	refract/libreferee_la-bootstrap.lo \
 	refract/libreferee_la-schema_registry.lo \
 	referee_sqlite/libreferee_la-sqlite_store.lo
 libreferee_la_OBJECTS = $(am_libreferee_la_OBJECTS)
@@ -169,6 +170,7 @@ am__maybe_remake_depfiles = depfiles
 am__depfiles_remade = conch_shell/$(DEPDIR)/conch.Po \
 	referee/$(DEPDIR)/libreferee_la-referee.Plo \
 	referee_sqlite/$(DEPDIR)/libreferee_la-sqlite_store.Plo \
+	refract/$(DEPDIR)/libreferee_la-bootstrap.Plo \
 	refract/$(DEPDIR)/libreferee_la-schema_registry.Plo \
 	services/$(DEPDIR)/libreferee_la-service.Plo
 am__mv = mv -f
@@ -378,6 +380,8 @@ libreferee_la_SOURCES = \
    referee/referee.cc \
    services/service.h \
    services/service.cc \
+   refract/bootstrap.h \
+   refract/bootstrap.cc \
    refract/schema_registry.h \
    refract/schema_registry.cc \
    referee_sqlite/sqlite_store.h \
@@ -528,6 +532,8 @@ refract/$(am__dirstamp):
 refract/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) refract/$(DEPDIR)
 	@: > refract/$(DEPDIR)/$(am__dirstamp)
+refract/libreferee_la-bootstrap.lo: refract/$(am__dirstamp) \
+	refract/$(DEPDIR)/$(am__dirstamp)
 refract/libreferee_la-schema_registry.lo: refract/$(am__dirstamp) \
 	refract/$(DEPDIR)/$(am__dirstamp)
 referee_sqlite/$(am__dirstamp):
@@ -573,6 +579,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@conch_shell/$(DEPDIR)/conch.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@referee/$(DEPDIR)/libreferee_la-referee.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@referee_sqlite/$(DEPDIR)/libreferee_la-sqlite_store.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@refract/$(DEPDIR)/libreferee_la-bootstrap.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@refract/$(DEPDIR)/libreferee_la-schema_registry.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@services/$(DEPDIR)/libreferee_la-service.Plo@am__quote@ # am--include-marker
 
@@ -619,6 +626,13 @@ services/libreferee_la-service.lo: services/service.cc
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='services/service.cc' object='services/libreferee_la-service.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libreferee_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o services/libreferee_la-service.lo `test -f 'services/service.cc' || echo '$(srcdir)/'`services/service.cc
+
+refract/libreferee_la-bootstrap.lo: refract/bootstrap.cc
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libreferee_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT refract/libreferee_la-bootstrap.lo -MD -MP -MF refract/$(DEPDIR)/libreferee_la-bootstrap.Tpo -c -o refract/libreferee_la-bootstrap.lo `test -f 'refract/bootstrap.cc' || echo '$(srcdir)/'`refract/bootstrap.cc
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) refract/$(DEPDIR)/libreferee_la-bootstrap.Tpo refract/$(DEPDIR)/libreferee_la-bootstrap.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='refract/bootstrap.cc' object='refract/libreferee_la-bootstrap.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libreferee_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o refract/libreferee_la-bootstrap.lo `test -f 'refract/bootstrap.cc' || echo '$(srcdir)/'`refract/bootstrap.cc
 
 refract/libreferee_la-schema_registry.lo: refract/schema_registry.cc
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libreferee_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT refract/libreferee_la-schema_registry.lo -MD -MP -MF refract/$(DEPDIR)/libreferee_la-schema_registry.Tpo -c -o refract/libreferee_la-schema_registry.lo `test -f 'refract/schema_registry.cc' || echo '$(srcdir)/'`refract/schema_registry.cc
@@ -807,6 +821,7 @@ distclean: distclean-am
 		-rm -f conch_shell/$(DEPDIR)/conch.Po
 	-rm -f referee/$(DEPDIR)/libreferee_la-referee.Plo
 	-rm -f referee_sqlite/$(DEPDIR)/libreferee_la-sqlite_store.Plo
+	-rm -f refract/$(DEPDIR)/libreferee_la-bootstrap.Plo
 	-rm -f refract/$(DEPDIR)/libreferee_la-schema_registry.Plo
 	-rm -f services/$(DEPDIR)/libreferee_la-service.Plo
 	-rm -f Makefile
@@ -857,6 +872,7 @@ maintainer-clean: maintainer-clean-am
 		-rm -f conch_shell/$(DEPDIR)/conch.Po
 	-rm -f referee/$(DEPDIR)/libreferee_la-referee.Plo
 	-rm -f referee_sqlite/$(DEPDIR)/libreferee_la-sqlite_store.Plo
+	-rm -f refract/$(DEPDIR)/libreferee_la-bootstrap.Plo
 	-rm -f refract/$(DEPDIR)/libreferee_la-schema_registry.Plo
 	-rm -f services/$(DEPDIR)/libreferee_la-service.Plo
 	-rm -f Makefile

--- a/src/refract/bootstrap.cc
+++ b/src/refract/bootstrap.cc
@@ -1,0 +1,131 @@
+#include "refract/bootstrap.h"
+
+#include <array>
+#include <cstdint>
+
+namespace iris::refract {
+
+namespace {
+
+constexpr referee::TypeID kTypeString{0x1001ULL};
+constexpr referee::TypeID kTypeU64{0x1002ULL};
+constexpr referee::TypeID kTypeBool{0x1003ULL};
+
+constexpr referee::TypeID kTypeFieldDefinition{0x5246524346000001ULL};
+constexpr referee::TypeID kTypeOperationDefinition{0x5246524346000002ULL};
+constexpr referee::TypeID kTypeSignatureDefinition{0x5246524346000003ULL};
+constexpr referee::TypeID kTypeRelationshipSpec{0x5246524346000004ULL};
+
+referee::ObjectID definition_id_for(referee::TypeID type_id) {
+  referee::ObjectID id{};
+  std::array<std::uint8_t, 8> tag = { 'R','E','F','R','A','C','T','0' };
+  for (std::size_t i = 0; i < tag.size(); ++i) id.bytes[i] = tag[i];
+
+  std::uint64_t v = type_id.v;
+  for (int i = 0; i < 8; ++i) {
+    id.bytes[15 - i] = (std::uint8_t)(v & 0xFFu);
+    v >>= 8;
+  }
+  return id;
+}
+
+TypeDefinition make_primitive(referee::TypeID type_id, const std::string& name) {
+  TypeDefinition def;
+  def.type_id = type_id;
+  def.name = name;
+  def.namespace_name = "Refract";
+  def.version = 1;
+  return def;
+}
+
+TypeDefinition make_type_definition() {
+  TypeDefinition def;
+  def.type_id = kTypeDefinitionType;
+  def.name = "TypeDefinition";
+  def.namespace_name = "Refract";
+  def.version = 1;
+
+  def.fields.push_back(FieldDefinition{ "type_id", kTypeU64, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "name", kTypeString, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "namespace", kTypeString, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "version", kTypeU64, true, std::nullopt });
+  return def;
+}
+
+TypeDefinition make_field_definition() {
+  TypeDefinition def;
+  def.type_id = kTypeFieldDefinition;
+  def.name = "FieldDefinition";
+  def.namespace_name = "Refract";
+  def.version = 1;
+
+  def.fields.push_back(FieldDefinition{ "name", kTypeString, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "type_id", kTypeU64, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "required", kTypeBool, false, std::nullopt });
+  return def;
+}
+
+TypeDefinition make_signature_definition() {
+  TypeDefinition def;
+  def.type_id = kTypeSignatureDefinition;
+  def.name = "SignatureDefinition";
+  def.namespace_name = "Refract";
+  def.version = 1;
+  return def;
+}
+
+TypeDefinition make_operation_definition() {
+  TypeDefinition def;
+  def.type_id = kTypeOperationDefinition;
+  def.name = "OperationDefinition";
+  def.namespace_name = "Refract";
+  def.version = 1;
+  return def;
+}
+
+TypeDefinition make_relationship_spec() {
+  TypeDefinition def;
+  def.type_id = kTypeRelationshipSpec;
+  def.name = "RelationshipSpec";
+  def.namespace_name = "Refract";
+  def.version = 1;
+  return def;
+}
+
+} // namespace
+
+std::vector<TypeDefinition> core_schema_definitions() {
+  std::vector<TypeDefinition> defs;
+  defs.reserve(8);
+  defs.push_back(make_primitive(kTypeString, "String"));
+  defs.push_back(make_primitive(kTypeU64, "U64"));
+  defs.push_back(make_primitive(kTypeBool, "Bool"));
+  defs.push_back(make_type_definition());
+  defs.push_back(make_field_definition());
+  defs.push_back(make_signature_definition());
+  defs.push_back(make_operation_definition());
+  defs.push_back(make_relationship_spec());
+  return defs;
+}
+
+referee::Result<BootstrapResult> bootstrap_core_schema(SchemaRegistry& registry) {
+  BootstrapResult out;
+  auto defs = core_schema_definitions();
+
+  for (const auto& def : defs) {
+    auto existing = registry.get_definition_by_type(def.type_id);
+    if (!existing) return referee::Result<BootstrapResult>::err(existing.error->message);
+    if (existing.value->has_value()) {
+      ++out.existing;
+      continue;
+    }
+    auto definition_id = definition_id_for(def.type_id);
+    auto reg = registry.register_definition_with_id(def, definition_id);
+    if (!reg) return referee::Result<BootstrapResult>::err(reg.error->message);
+    ++out.inserted;
+  }
+
+  return referee::Result<BootstrapResult>::ok(out);
+}
+
+} // namespace iris::refract

--- a/src/refract/bootstrap.h
+++ b/src/refract/bootstrap.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "refract/schema_registry.h"
+
+#include <vector>
+
+namespace iris::refract {
+
+struct BootstrapResult {
+  std::size_t inserted{0};
+  std::size_t existing{0};
+};
+
+// Returns the canonical TypeDefinition set for Refract core schema.
+std::vector<TypeDefinition> core_schema_definitions();
+
+// Ensures core schema definitions exist in Referee (idempotent).
+referee::Result<BootstrapResult> bootstrap_core_schema(SchemaRegistry& registry);
+
+} // namespace iris::refract

--- a/src/refract/schema_registry.cc
+++ b/src/refract/schema_registry.cc
@@ -165,6 +165,18 @@ referee::Result<DefinitionRecord> SchemaRegistry::register_definition(const Type
   return record_from_object(createR.value.value());
 }
 
+referee::Result<DefinitionRecord> SchemaRegistry::register_definition_with_id(
+    const TypeDefinition& def, referee::ObjectID definition_id) {
+  if (def.name.empty()) return referee::Result<DefinitionRecord>::err("definition name is empty");
+  if (def.type_id.v == 0) return referee::Result<DefinitionRecord>::err("type_id is zero");
+
+  auto payload = encode_definition(def);
+  auto createR = store_.create_object_with_id(definition_id, kTypeDefinitionType, definition_id, payload);
+  if (!createR) return referee::Result<DefinitionRecord>::err(createR.error->message);
+
+  return record_from_object(createR.value.value());
+}
+
 referee::Result<std::optional<DefinitionRecord>> SchemaRegistry::get_definition_by_id(referee::ObjectID id) {
   auto recR = store_.get_latest(id);
   if (!recR) return referee::Result<std::optional<DefinitionRecord>>::err(recR.error->message);

--- a/src/refract/schema_registry.h
+++ b/src/refract/schema_registry.h
@@ -68,6 +68,8 @@ public:
   explicit SchemaRegistry(referee::SqliteStore& store);
 
   referee::Result<DefinitionRecord> register_definition(const TypeDefinition& def);
+  referee::Result<DefinitionRecord> register_definition_with_id(const TypeDefinition& def,
+                                                                referee::ObjectID definition_id);
   referee::Result<std::optional<DefinitionRecord>> get_definition_by_id(referee::ObjectID id);
   referee::Result<std::optional<DefinitionRecord>> get_definition_by_type(referee::TypeID type);
   referee::Result<std::vector<TypeSummary>> list_types();

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,7 +2,7 @@ AM_CXXFLAGS = -Wall -Wextra -Wpedantic
 AM_CPPFLAGS = -I$(top_srcdir)/src $(CHECK_CFLAGS)
 AM_TESTS_ENVIRONMENT = CK_FORK=no
 
-TESTS = test_referee_core test_service_ipc test_refract_registry
+TESTS = test_referee_core test_service_ipc test_refract_registry test_refract_bootstrap
 check_PROGRAMS = $(TESTS)
 
 test_referee_core_SOURCES = test_referee_core.cc
@@ -13,3 +13,6 @@ test_service_ipc_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la
 
 test_refract_registry_SOURCES = test_refract_registry.cc
 test_refract_registry_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la
+
+test_refract_bootstrap_SOURCES = test_refract_bootstrap.cc
+test_refract_bootstrap_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -88,7 +88,7 @@ POST_UNINSTALL = :
 build_triplet = @build@
 host_triplet = @host@
 TESTS = test_referee_core$(EXEEXT) test_service_ipc$(EXEEXT) \
-	test_refract_registry$(EXEEXT)
+	test_refract_registry$(EXEEXT) test_refract_bootstrap$(EXEEXT)
 check_PROGRAMS = $(am__EXEEXT_1)
 subdir = tests
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
@@ -104,7 +104,7 @@ CONFIG_HEADER = $(top_builddir)/config.h
 CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
 am__EXEEXT_1 = test_referee_core$(EXEEXT) test_service_ipc$(EXEEXT) \
-	test_refract_registry$(EXEEXT)
+	test_refract_registry$(EXEEXT) test_refract_bootstrap$(EXEEXT)
 am_test_referee_core_OBJECTS = test_referee_core.$(OBJEXT)
 test_referee_core_OBJECTS = $(am_test_referee_core_OBJECTS)
 am__DEPENDENCIES_1 =
@@ -114,6 +114,10 @@ AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
+am_test_refract_bootstrap_OBJECTS = test_refract_bootstrap.$(OBJEXT)
+test_refract_bootstrap_OBJECTS = $(am_test_refract_bootstrap_OBJECTS)
+test_refract_bootstrap_DEPENDENCIES = $(am__DEPENDENCIES_1) \
+	$(top_builddir)/src/libreferee.la
 am_test_refract_registry_OBJECTS = test_refract_registry.$(OBJEXT)
 test_refract_registry_OBJECTS = $(am_test_refract_registry_OBJECTS)
 test_refract_registry_DEPENDENCIES = $(am__DEPENDENCIES_1) \
@@ -138,6 +142,7 @@ DEFAULT_INCLUDES = -I.@am__isrc@ -I$(top_builddir)
 depcomp = $(SHELL) $(top_srcdir)/depcomp
 am__maybe_remake_depfiles = depfiles
 am__depfiles_remade = ./$(DEPDIR)/test_referee_core.Po \
+	./$(DEPDIR)/test_refract_bootstrap.Po \
 	./$(DEPDIR)/test_refract_registry.Po \
 	./$(DEPDIR)/test_service_ipc.Po
 am__mv = mv -f
@@ -160,8 +165,10 @@ am__v_CXXLD_ = $(am__v_CXXLD_@AM_DEFAULT_V@)
 am__v_CXXLD_0 = @echo "  CXXLD   " $@;
 am__v_CXXLD_1 = 
 SOURCES = $(test_referee_core_SOURCES) \
+	$(test_refract_bootstrap_SOURCES) \
 	$(test_refract_registry_SOURCES) $(test_service_ipc_SOURCES)
 DIST_SOURCES = $(test_referee_core_SOURCES) \
+	$(test_refract_bootstrap_SOURCES) \
 	$(test_refract_registry_SOURCES) $(test_service_ipc_SOURCES)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
@@ -534,6 +541,8 @@ test_service_ipc_SOURCES = test_service_ipc.cc
 test_service_ipc_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la
 test_refract_registry_SOURCES = test_refract_registry.cc
 test_refract_registry_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la
+test_refract_bootstrap_SOURCES = test_refract_bootstrap.cc
+test_refract_bootstrap_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la
 all: all-am
 
 .SUFFIXES:
@@ -581,6 +590,10 @@ test_referee_core$(EXEEXT): $(test_referee_core_OBJECTS) $(test_referee_core_DEP
 	@rm -f test_referee_core$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(test_referee_core_OBJECTS) $(test_referee_core_LDADD) $(LIBS)
 
+test_refract_bootstrap$(EXEEXT): $(test_refract_bootstrap_OBJECTS) $(test_refract_bootstrap_DEPENDENCIES) $(EXTRA_test_refract_bootstrap_DEPENDENCIES) 
+	@rm -f test_refract_bootstrap$(EXEEXT)
+	$(AM_V_CXXLD)$(CXXLINK) $(test_refract_bootstrap_OBJECTS) $(test_refract_bootstrap_LDADD) $(LIBS)
+
 test_refract_registry$(EXEEXT): $(test_refract_registry_OBJECTS) $(test_refract_registry_DEPENDENCIES) $(EXTRA_test_refract_registry_DEPENDENCIES) 
 	@rm -f test_refract_registry$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(test_refract_registry_OBJECTS) $(test_refract_registry_LDADD) $(LIBS)
@@ -596,6 +609,7 @@ distclean-compile:
 	-rm -f *.tab.c
 
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_referee_core.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_refract_bootstrap.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_refract_registry.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_service_ipc.Po@am__quote@ # am--include-marker
 
@@ -849,6 +863,13 @@ test_refract_registry.log: test_refract_registry$(EXEEXT)
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+test_refract_bootstrap.log: test_refract_bootstrap$(EXEEXT)
+	@p='test_refract_bootstrap$(EXEEXT)'; \
+	b='test_refract_bootstrap'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 .test.log:
 	@p='$<'; \
 	$(am__set_b); \
@@ -942,6 +963,7 @@ clean-am: clean-checkPROGRAMS clean-generic clean-libtool \
 
 distclean: distclean-am
 		-rm -f ./$(DEPDIR)/test_referee_core.Po
+	-rm -f ./$(DEPDIR)/test_refract_bootstrap.Po
 	-rm -f ./$(DEPDIR)/test_refract_registry.Po
 	-rm -f ./$(DEPDIR)/test_service_ipc.Po
 	-rm -f Makefile
@@ -990,6 +1012,7 @@ installcheck-am:
 
 maintainer-clean: maintainer-clean-am
 		-rm -f ./$(DEPDIR)/test_referee_core.Po
+	-rm -f ./$(DEPDIR)/test_refract_bootstrap.Po
 	-rm -f ./$(DEPDIR)/test_refract_registry.Po
 	-rm -f ./$(DEPDIR)/test_service_ipc.Po
 	-rm -f Makefile

--- a/tests/test_refract_bootstrap.cc
+++ b/tests/test_refract_bootstrap.cc
@@ -1,0 +1,68 @@
+extern "C" {
+#include <check.h>
+}
+#ifdef fail
+#undef fail
+#endif
+
+#include "refract/bootstrap.h"
+#include "refract/schema_registry.h"
+#include "referee/referee.h"
+#include "referee_sqlite/sqlite_store.h"
+
+#include <string>
+
+using namespace referee;
+using namespace iris::refract;
+
+namespace {
+
+template <typename T>
+const char* result_message(const Result<T>& r) {
+  return r.error.has_value() ? r.error->message.c_str() : "ok";
+}
+
+} // namespace
+
+START_TEST(test_bootstrap_idempotent)
+{
+  SqliteStore store(SqliteConfig{ .filename=":memory:", .enable_wal=false });
+  ck_assert_msg(store.open(), "open failed");
+  ck_assert_msg(store.ensure_schema(), "ensure_schema failed");
+
+  SchemaRegistry registry(store);
+
+  auto first = bootstrap_core_schema(registry);
+  ck_assert_msg(first, "bootstrap failed: %s", result_message(first));
+  ck_assert_int_gt((int)first.value->inserted, 0);
+
+  auto second = bootstrap_core_schema(registry);
+  ck_assert_msg(second, "bootstrap failed: %s", result_message(second));
+  ck_assert_int_eq((int)second.value->inserted, 0);
+
+  auto listR = registry.list_types();
+  ck_assert_msg(listR, "list_types failed: %s", result_message(listR));
+  ck_assert_int_gt((int)listR.value->size(), 0);
+
+  ck_assert_msg(store.close(), "close failed");
+}
+END_TEST
+
+Suite* refract_bootstrap_suite(void) {
+  Suite* s = suite_create("RefractBootstrap");
+  TCase* tc = tcase_create("core");
+
+  tcase_add_test(tc, test_bootstrap_idempotent);
+
+  suite_add_tcase(s, tc);
+  return s;
+}
+
+int main(void) {
+  Suite* s = refract_bootstrap_suite();
+  SRunner* sr = srunner_create(s);
+  srunner_run_all(sr, CK_NORMAL);
+  int failures = srunner_ntests_failed(sr);
+  srunner_free(sr);
+  return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- add core Refract schema bootstrap with deterministic IDs
- expose register_definition_with_id in SchemaRegistry
- add bootstrap unit test

## Testing
- not run (not requested)