### PR TITLE
feat: integrate await with task cancellation

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,6 +12,8 @@ libreferee_la_SOURCES = \
    referee/referee.cc \
    ceo/task_registry.h \
    ceo/task_registry.cc \
+   exec/await.h \
+   exec/await.cc \
    exec/waitables.h \
    exec/waitables.cc \
    services/service.h \
@@ -30,4 +32,5 @@ include_HEADERS = referee/referee.h \
    services/service.h \
    refract/schema_registry.h \
    ceo/task_registry.h \
-   exec/waitables.h
+   exec/waitables.h \
+   exec/await.h

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -140,7 +140,7 @@ am__DEPENDENCIES_1 =
 libreferee_la_DEPENDENCIES = $(am__DEPENDENCIES_1)
 am__dirstamp = $(am__leading_dot)dirstamp
 am_libreferee_la_OBJECTS = referee/libreferee_la-referee.lo \
-	ceo/libreferee_la-task_registry.lo \
+	ceo/libreferee_la-task_registry.lo exec/libreferee_la-await.lo \
 	exec/libreferee_la-waitables.lo \
 	services/libreferee_la-service.lo \
 	refract/libreferee_la-bootstrap.lo \
@@ -171,6 +171,7 @@ depcomp = $(SHELL) $(top_srcdir)/depcomp
 am__maybe_remake_depfiles = depfiles
 am__depfiles_remade = ceo/$(DEPDIR)/libreferee_la-task_registry.Plo \
 	conch_shell/$(DEPDIR)/conch.Po \
+	exec/$(DEPDIR)/libreferee_la-await.Plo \
 	exec/$(DEPDIR)/libreferee_la-waitables.Plo \
 	referee/$(DEPDIR)/libreferee_la-referee.Plo \
 	referee_sqlite/$(DEPDIR)/libreferee_la-sqlite_store.Plo \
@@ -384,6 +385,8 @@ libreferee_la_SOURCES = \
    referee/referee.cc \
    ceo/task_registry.h \
    ceo/task_registry.cc \
+   exec/await.h \
+   exec/await.cc \
    exec/waitables.h \
    exec/waitables.cc \
    services/service.h \
@@ -401,7 +404,8 @@ include_HEADERS = referee/referee.h \
    services/service.h \
    refract/schema_registry.h \
    ceo/task_registry.h \
-   exec/waitables.h
+   exec/waitables.h \
+   exec/await.h
 
 all: all-am
 
@@ -542,6 +546,8 @@ exec/$(am__dirstamp):
 exec/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) exec/$(DEPDIR)
 	@: > exec/$(DEPDIR)/$(am__dirstamp)
+exec/libreferee_la-await.lo: exec/$(am__dirstamp) \
+	exec/$(DEPDIR)/$(am__dirstamp)
 exec/libreferee_la-waitables.lo: exec/$(am__dirstamp) \
 	exec/$(DEPDIR)/$(am__dirstamp)
 services/$(am__dirstamp):
@@ -608,6 +614,7 @@ distclean-compile:
 
 @AMDEP_TRUE@@am__include@ @am__quote@ceo/$(DEPDIR)/libreferee_la-task_registry.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@conch_shell/$(DEPDIR)/conch.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@exec/$(DEPDIR)/libreferee_la-await.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@exec/$(DEPDIR)/libreferee_la-waitables.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@referee/$(DEPDIR)/libreferee_la-referee.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@referee_sqlite/$(DEPDIR)/libreferee_la-sqlite_store.Plo@am__quote@ # am--include-marker
@@ -658,6 +665,13 @@ ceo/libreferee_la-task_registry.lo: ceo/task_registry.cc
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='ceo/task_registry.cc' object='ceo/libreferee_la-task_registry.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libreferee_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o ceo/libreferee_la-task_registry.lo `test -f 'ceo/task_registry.cc' || echo '$(srcdir)/'`ceo/task_registry.cc
+
+exec/libreferee_la-await.lo: exec/await.cc
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libreferee_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT exec/libreferee_la-await.lo -MD -MP -MF exec/$(DEPDIR)/libreferee_la-await.Tpo -c -o exec/libreferee_la-await.lo `test -f 'exec/await.cc' || echo '$(srcdir)/'`exec/await.cc
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) exec/$(DEPDIR)/libreferee_la-await.Tpo exec/$(DEPDIR)/libreferee_la-await.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='exec/await.cc' object='exec/libreferee_la-await.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libreferee_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o exec/libreferee_la-await.lo `test -f 'exec/await.cc' || echo '$(srcdir)/'`exec/await.cc
 
 exec/libreferee_la-waitables.lo: exec/waitables.cc
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libreferee_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT exec/libreferee_la-waitables.lo -MD -MP -MF exec/$(DEPDIR)/libreferee_la-waitables.Tpo -c -o exec/libreferee_la-waitables.lo `test -f 'exec/waitables.cc' || echo '$(srcdir)/'`exec/waitables.cc
@@ -872,6 +886,7 @@ clean-am: clean-binPROGRAMS clean-generic clean-libLTLIBRARIES \
 distclean: distclean-am
 		-rm -f ceo/$(DEPDIR)/libreferee_la-task_registry.Plo
 	-rm -f conch_shell/$(DEPDIR)/conch.Po
+	-rm -f exec/$(DEPDIR)/libreferee_la-await.Plo
 	-rm -f exec/$(DEPDIR)/libreferee_la-waitables.Plo
 	-rm -f referee/$(DEPDIR)/libreferee_la-referee.Plo
 	-rm -f referee_sqlite/$(DEPDIR)/libreferee_la-sqlite_store.Plo
@@ -925,6 +940,7 @@ installcheck-am:
 maintainer-clean: maintainer-clean-am
 		-rm -f ceo/$(DEPDIR)/libreferee_la-task_registry.Plo
 	-rm -f conch_shell/$(DEPDIR)/conch.Po
+	-rm -f exec/$(DEPDIR)/libreferee_la-await.Plo
 	-rm -f exec/$(DEPDIR)/libreferee_la-waitables.Plo
 	-rm -f referee/$(DEPDIR)/libreferee_la-referee.Plo
 	-rm -f referee_sqlite/$(DEPDIR)/libreferee_la-sqlite_store.Plo

--- a/src/ceo/task_registry.cc
+++ b/src/ceo/task_registry.cc
@@ -40,6 +40,22 @@ referee::Result<TaskRecord> TaskRegistry::spawn_task(const referee::ObjectID& ob
   return referee::Result<TaskRecord>::ok(insert.first->second);
 }
 
+referee::Result<void> TaskRegistry::wait_task(TaskID id) {
+  auto* rec = find_task(id);
+  if (!rec) return referee::Result<void>::err("task not found");
+  if (is_terminal(rec->state)) return referee::Result<void>::err("task already terminal");
+  rec->state = TaskState::Waiting;
+  return referee::Result<void>::ok();
+}
+
+referee::Result<void> TaskRegistry::resume_task(TaskID id) {
+  auto* rec = find_task(id);
+  if (!rec) return referee::Result<void>::err("task not found");
+  if (is_terminal(rec->state)) return referee::Result<void>::err("task already terminal");
+  rec->state = TaskState::Running;
+  return referee::Result<void>::ok();
+}
+
 referee::Result<void> TaskRegistry::cancel_task(TaskID id) {
   auto* rec = find_task(id);
   if (!rec) return referee::Result<void>::err("task not found");
@@ -111,6 +127,7 @@ const char* to_string(TaskState state) {
   switch (state) {
     case TaskState::Created: return "Created";
     case TaskState::Running: return "Running";
+    case TaskState::Waiting: return "Waiting";
     case TaskState::CancelRequested: return "CancelRequested";
     case TaskState::Canceled: return "Canceled";
     case TaskState::Completed: return "Completed";

--- a/src/ceo/task_registry.h
+++ b/src/ceo/task_registry.h
@@ -15,6 +15,7 @@ using TaskID = std::uint64_t;
 enum class TaskState {
   Created,
   Running,
+  Waiting,
   CancelRequested,
   Canceled,
   Completed,
@@ -38,6 +39,8 @@ public:
   referee::Result<TaskRecord> spawn_task(const referee::ObjectID& object_id,
                                          std::optional<TaskID> parent = std::nullopt,
                                          std::string name = {});
+  referee::Result<void> wait_task(TaskID id);
+  referee::Result<void> resume_task(TaskID id);
   referee::Result<void> cancel_task(TaskID id);
   referee::Result<void> mark_canceled(TaskID id);
   referee::Result<void> kill_task(TaskID id);

--- a/src/exec/await.cc
+++ b/src/exec/await.cc
@@ -1,0 +1,41 @@
+#include "exec/await.h"
+
+namespace iris::exec {
+
+referee::Result<WaitResult> await_task(Waitable& waitable, ceo::TaskRegistry& registry, ceo::TaskID task) {
+  auto taskR = registry.get_task(task);
+  if (!taskR) return referee::Result<WaitResult>::err(taskR.error->message);
+  if (!taskR.value->has_value()) return referee::Result<WaitResult>::err("task not found");
+
+  const auto& rec = taskR.value->value();
+  if (rec.state == ceo::TaskState::CancelRequested) {
+    auto canceled = registry.mark_canceled(task);
+    if (!canceled) return referee::Result<WaitResult>::err(canceled.error->message);
+    return referee::Result<WaitResult>::ok(WaitResult{true, {}});
+  }
+
+  auto waitR = waitable.wait(task);
+  if (!waitR.ready) {
+    auto waitSet = registry.wait_task(task);
+    if (!waitSet) return referee::Result<WaitResult>::err(waitSet.error->message);
+  }
+  return referee::Result<WaitResult>::ok(std::move(waitR));
+}
+
+AwaitOutcome handle_wait_result(ceo::TaskRegistry& registry, const WaitResult& result) {
+  AwaitOutcome out;
+  for (auto task_id : result.woken) {
+    auto taskR = registry.get_task(task_id);
+    if (!taskR || !taskR.value->has_value()) continue;
+
+    const auto& rec = taskR.value->value();
+    if (rec.state == ceo::TaskState::CancelRequested) {
+      if (registry.mark_canceled(task_id)) out.canceled.push_back(task_id);
+      continue;
+    }
+    if (registry.resume_task(task_id)) out.resumed.push_back(task_id);
+  }
+  return out;
+}
+
+} // namespace iris::exec

--- a/src/exec/await.h
+++ b/src/exec/await.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "ceo/task_registry.h"
+#include "exec/waitables.h"
+
+namespace iris::exec {
+
+struct AwaitOutcome {
+  std::vector<ceo::TaskID> resumed;
+  std::vector<ceo::TaskID> canceled;
+};
+
+referee::Result<WaitResult> await_task(Waitable& waitable, ceo::TaskRegistry& registry, ceo::TaskID task);
+AwaitOutcome handle_wait_result(ceo::TaskRegistry& registry, const WaitResult& result);
+
+} // namespace iris::exec

--- a/src/exec/waitables.h
+++ b/src/exec/waitables.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "ceo/task_registry.h"
-#include "referee/referee.h"
 
 #include <deque>
 #include <optional>

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,7 +2,7 @@ AM_CXXFLAGS = -Wall -Wextra -Wpedantic
 AM_CPPFLAGS = -I$(top_srcdir)/src $(CHECK_CFLAGS)
 AM_TESTS_ENVIRONMENT = CK_FORK=no
 
-TESTS = test_referee_core test_service_ipc test_refract_registry test_refract_bootstrap test_ceo_tasks test_exec_waitables
+TESTS = test_referee_core test_service_ipc test_refract_registry test_refract_bootstrap test_ceo_tasks test_exec_waitables test_exec_integration
 check_PROGRAMS = $(TESTS)
 
 test_referee_core_SOURCES = test_referee_core.cc
@@ -22,3 +22,6 @@ test_ceo_tasks_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la
 
 test_exec_waitables_SOURCES = test_exec_waitables.cc
 test_exec_waitables_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la
+
+test_exec_integration_SOURCES = test_exec_integration.cc
+test_exec_integration_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -89,7 +89,8 @@ build_triplet = @build@
 host_triplet = @host@
 TESTS = test_referee_core$(EXEEXT) test_service_ipc$(EXEEXT) \
 	test_refract_registry$(EXEEXT) test_refract_bootstrap$(EXEEXT) \
-	test_ceo_tasks$(EXEEXT) test_exec_waitables$(EXEEXT)
+	test_ceo_tasks$(EXEEXT) test_exec_waitables$(EXEEXT) \
+	test_exec_integration$(EXEEXT)
 check_PROGRAMS = $(am__EXEEXT_1)
 subdir = tests
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
@@ -106,7 +107,8 @@ CONFIG_CLEAN_FILES =
 CONFIG_CLEAN_VPATH_FILES =
 am__EXEEXT_1 = test_referee_core$(EXEEXT) test_service_ipc$(EXEEXT) \
 	test_refract_registry$(EXEEXT) test_refract_bootstrap$(EXEEXT) \
-	test_ceo_tasks$(EXEEXT) test_exec_waitables$(EXEEXT)
+	test_ceo_tasks$(EXEEXT) test_exec_waitables$(EXEEXT) \
+	test_exec_integration$(EXEEXT)
 am_test_ceo_tasks_OBJECTS = test_ceo_tasks.$(OBJEXT)
 test_ceo_tasks_OBJECTS = $(am_test_ceo_tasks_OBJECTS)
 am__DEPENDENCIES_1 =
@@ -116,6 +118,10 @@ AM_V_lt = $(am__v_lt_@AM_V@)
 am__v_lt_ = $(am__v_lt_@AM_DEFAULT_V@)
 am__v_lt_0 = --silent
 am__v_lt_1 = 
+am_test_exec_integration_OBJECTS = test_exec_integration.$(OBJEXT)
+test_exec_integration_OBJECTS = $(am_test_exec_integration_OBJECTS)
+test_exec_integration_DEPENDENCIES = $(am__DEPENDENCIES_1) \
+	$(top_builddir)/src/libreferee.la
 am_test_exec_waitables_OBJECTS = test_exec_waitables.$(OBJEXT)
 test_exec_waitables_OBJECTS = $(am_test_exec_waitables_OBJECTS)
 test_exec_waitables_DEPENDENCIES = $(am__DEPENDENCIES_1) \
@@ -152,6 +158,7 @@ DEFAULT_INCLUDES = -I.@am__isrc@ -I$(top_builddir)
 depcomp = $(SHELL) $(top_srcdir)/depcomp
 am__maybe_remake_depfiles = depfiles
 am__depfiles_remade = ./$(DEPDIR)/test_ceo_tasks.Po \
+	./$(DEPDIR)/test_exec_integration.Po \
 	./$(DEPDIR)/test_exec_waitables.Po \
 	./$(DEPDIR)/test_referee_core.Po \
 	./$(DEPDIR)/test_refract_bootstrap.Po \
@@ -176,10 +183,12 @@ AM_V_CXXLD = $(am__v_CXXLD_@AM_V@)
 am__v_CXXLD_ = $(am__v_CXXLD_@AM_DEFAULT_V@)
 am__v_CXXLD_0 = @echo "  CXXLD   " $@;
 am__v_CXXLD_1 = 
-SOURCES = $(test_ceo_tasks_SOURCES) $(test_exec_waitables_SOURCES) \
-	$(test_referee_core_SOURCES) $(test_refract_bootstrap_SOURCES) \
+SOURCES = $(test_ceo_tasks_SOURCES) $(test_exec_integration_SOURCES) \
+	$(test_exec_waitables_SOURCES) $(test_referee_core_SOURCES) \
+	$(test_refract_bootstrap_SOURCES) \
 	$(test_refract_registry_SOURCES) $(test_service_ipc_SOURCES)
 DIST_SOURCES = $(test_ceo_tasks_SOURCES) \
+	$(test_exec_integration_SOURCES) \
 	$(test_exec_waitables_SOURCES) $(test_referee_core_SOURCES) \
 	$(test_refract_bootstrap_SOURCES) \
 	$(test_refract_registry_SOURCES) $(test_service_ipc_SOURCES)
@@ -560,6 +569,8 @@ test_ceo_tasks_SOURCES = test_ceo_tasks.cc
 test_ceo_tasks_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la
 test_exec_waitables_SOURCES = test_exec_waitables.cc
 test_exec_waitables_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la
+test_exec_integration_SOURCES = test_exec_integration.cc
+test_exec_integration_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la
 all: all-am
 
 .SUFFIXES:
@@ -607,6 +618,10 @@ test_ceo_tasks$(EXEEXT): $(test_ceo_tasks_OBJECTS) $(test_ceo_tasks_DEPENDENCIES
 	@rm -f test_ceo_tasks$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(test_ceo_tasks_OBJECTS) $(test_ceo_tasks_LDADD) $(LIBS)
 
+test_exec_integration$(EXEEXT): $(test_exec_integration_OBJECTS) $(test_exec_integration_DEPENDENCIES) $(EXTRA_test_exec_integration_DEPENDENCIES) 
+	@rm -f test_exec_integration$(EXEEXT)
+	$(AM_V_CXXLD)$(CXXLINK) $(test_exec_integration_OBJECTS) $(test_exec_integration_LDADD) $(LIBS)
+
 test_exec_waitables$(EXEEXT): $(test_exec_waitables_OBJECTS) $(test_exec_waitables_DEPENDENCIES) $(EXTRA_test_exec_waitables_DEPENDENCIES) 
 	@rm -f test_exec_waitables$(EXEEXT)
 	$(AM_V_CXXLD)$(CXXLINK) $(test_exec_waitables_OBJECTS) $(test_exec_waitables_LDADD) $(LIBS)
@@ -634,6 +649,7 @@ distclean-compile:
 	-rm -f *.tab.c
 
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_ceo_tasks.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_exec_integration.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_exec_waitables.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_referee_core.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/test_refract_bootstrap.Po@am__quote@ # am--include-marker
@@ -911,6 +927,13 @@ test_exec_waitables.log: test_exec_waitables$(EXEEXT)
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+test_exec_integration.log: test_exec_integration$(EXEEXT)
+	@p='test_exec_integration$(EXEEXT)'; \
+	b='test_exec_integration'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 .test.log:
 	@p='$<'; \
 	$(am__set_b); \
@@ -1004,6 +1027,7 @@ clean-am: clean-checkPROGRAMS clean-generic clean-libtool \
 
 distclean: distclean-am
 		-rm -f ./$(DEPDIR)/test_ceo_tasks.Po
+	-rm -f ./$(DEPDIR)/test_exec_integration.Po
 	-rm -f ./$(DEPDIR)/test_exec_waitables.Po
 	-rm -f ./$(DEPDIR)/test_referee_core.Po
 	-rm -f ./$(DEPDIR)/test_refract_bootstrap.Po
@@ -1055,6 +1079,7 @@ installcheck-am:
 
 maintainer-clean: maintainer-clean-am
 		-rm -f ./$(DEPDIR)/test_ceo_tasks.Po
+	-rm -f ./$(DEPDIR)/test_exec_integration.Po
 	-rm -f ./$(DEPDIR)/test_exec_waitables.Po
 	-rm -f ./$(DEPDIR)/test_referee_core.Po
 	-rm -f ./$(DEPDIR)/test_refract_bootstrap.Po

--- a/tests/test_ceo_tasks.cc
+++ b/tests/test_ceo_tasks.cc
@@ -43,6 +43,20 @@ START_TEST(test_state_transitions)
 }
 END_TEST
 
+START_TEST(test_wait_and_resume)
+{
+  TaskRegistry registry;
+  auto task = registry.spawn_task(referee::ObjectID::random());
+  ck_assert_msg(task, "spawn failed");
+
+  auto waitR = registry.wait_task(task.value->id);
+  ck_assert_msg(waitR, "wait_task failed");
+
+  auto resumeR = registry.resume_task(task.value->id);
+  ck_assert_msg(resumeR, "resume_task failed");
+}
+END_TEST
+
 START_TEST(test_invalid_parent)
 {
   TaskRegistry registry;
@@ -57,6 +71,7 @@ Suite* ceo_task_suite(void) {
 
   tcase_add_test(tc, test_spawn_and_parent_child);
   tcase_add_test(tc, test_state_transitions);
+  tcase_add_test(tc, test_wait_and_resume);
   tcase_add_test(tc, test_invalid_parent);
 
   suite_add_tcase(s, tc);

--- a/tests/test_exec_integration.cc
+++ b/tests/test_exec_integration.cc
@@ -1,0 +1,81 @@
+extern "C" {
+#include <check.h>
+}
+#ifdef fail
+#undef fail
+#endif
+
+#include "ceo/task_registry.h"
+#include "exec/await.h"
+#include "exec/waitables.h"
+
+using namespace iris::ceo;
+using namespace iris::exec;
+
+START_TEST(test_await_and_cancel)
+{
+  TaskRegistry registry;
+  Event ev(false);
+
+  auto task = registry.spawn_task(referee::ObjectID::random());
+  ck_assert_msg(task, "spawn failed");
+
+  auto waitR = await_task(ev, registry, task.value->id);
+  ck_assert_msg(waitR, "await_task failed");
+  ck_assert_msg(!waitR.value->ready, "expected await to block");
+
+  ck_assert_msg(registry.cancel_task(task.value->id), "cancel_task failed");
+
+  auto signal = ev.signal();
+  auto outcome = handle_wait_result(registry, signal);
+  ck_assert_int_eq((int)outcome.canceled.size(), 1);
+
+  auto state = registry.get_task(task.value->id);
+  ck_assert_msg(state, "get_task failed");
+  ck_assert(state.value->has_value());
+  ck_assert_int_eq((int)state.value->value().state, (int)TaskState::Canceled);
+}
+END_TEST
+
+START_TEST(test_await_resume)
+{
+  TaskRegistry registry;
+  Event ev(false);
+
+  auto task = registry.spawn_task(referee::ObjectID::random());
+  ck_assert_msg(task, "spawn failed");
+
+  auto waitR = await_task(ev, registry, task.value->id);
+  ck_assert_msg(waitR, "await_task failed");
+  ck_assert_msg(!waitR.value->ready, "expected await to block");
+
+  auto signal = ev.signal();
+  auto outcome = handle_wait_result(registry, signal);
+  ck_assert_int_eq((int)outcome.resumed.size(), 1);
+
+  auto state = registry.get_task(task.value->id);
+  ck_assert_msg(state, "get_task failed");
+  ck_assert(state.value->has_value());
+  ck_assert_int_eq((int)state.value->value().state, (int)TaskState::Running);
+}
+END_TEST
+
+Suite* exec_integration_suite(void) {
+  Suite* s = suite_create("ExecIntegration");
+  TCase* tc = tcase_create("core");
+
+  tcase_add_test(tc, test_await_and_cancel);
+  tcase_add_test(tc, test_await_resume);
+
+  suite_add_tcase(s, tc);
+  return s;
+}
+
+int main(void) {
+  Suite* s = exec_integration_suite();
+  SRunner* sr = srunner_create(s);
+  srunner_run_all(sr, CK_NORMAL);
+  int failures = srunner_ntests_failed(sr);
+  srunner_free(sr);
+  return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- add await helpers to bridge waitables and task registry
- add waiting state and resume handling
- add integration tests for await/cancel and await/resume

## Testing
- not run (not requested)