### PR TITLE
feat: add conch type authoring and bootstrap types

### DIFF
--- a/src/refract/bootstrap.cc
+++ b/src/refract/bootstrap.cc
@@ -10,11 +10,27 @@ namespace {
 constexpr referee::TypeID kTypeString{0x1001ULL};
 constexpr referee::TypeID kTypeU64{0x1002ULL};
 constexpr referee::TypeID kTypeBool{0x1003ULL};
+constexpr referee::TypeID kTypeObjectID{0x1004ULL};
+constexpr referee::TypeID kTypeTypeID{0x1005ULL};
+constexpr referee::TypeID kTypeVersion{0x1006ULL};
+constexpr referee::TypeID kTypeBytes{0x1007ULL};
 
 constexpr referee::TypeID kTypeFieldDefinition{0x5246524346000001ULL};
 constexpr referee::TypeID kTypeOperationDefinition{0x5246524346000002ULL};
 constexpr referee::TypeID kTypeSignatureDefinition{0x5246524346000003ULL};
 constexpr referee::TypeID kTypeRelationshipSpec{0x5246524346000004ULL};
+
+constexpr referee::TypeID kTypeRefereeObject{0x5245464500000001ULL};
+constexpr referee::TypeID kTypeRefereeEdge{0x5245464500000002ULL};
+
+constexpr referee::TypeID kTypeConchSession{0x434F4E4300000001ULL};
+constexpr referee::TypeID kTypeConchConcho{0x434F4E4300000002ULL};
+
+constexpr referee::TypeID kTypeVizPanel{0x56495A0000000001ULL};
+constexpr referee::TypeID kTypeVizTextLog{0x56495A0000000002ULL};
+constexpr referee::TypeID kTypeVizMetric{0x56495A0000000003ULL};
+constexpr referee::TypeID kTypeVizTable{0x56495A0000000004ULL};
+constexpr referee::TypeID kTypeVizTree{0x56495A0000000005ULL};
 
 referee::ObjectID definition_id_for(referee::TypeID type_id) {
   referee::ObjectID id{};
@@ -92,19 +108,133 @@ TypeDefinition make_relationship_spec() {
   return def;
 }
 
+TypeDefinition make_referee_object() {
+  TypeDefinition def;
+  def.type_id = kTypeRefereeObject;
+  def.name = "Object";
+  def.namespace_name = "Referee";
+  def.version = 1;
+
+  def.fields.push_back(FieldDefinition{ "object_id", kTypeObjectID, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "version", kTypeVersion, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "type_id", kTypeTypeID, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "definition_id", kTypeObjectID, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "payload", kTypeBytes, false, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "created_at_ms", kTypeU64, true, std::nullopt });
+  return def;
+}
+
+TypeDefinition make_referee_edge() {
+  TypeDefinition def;
+  def.type_id = kTypeRefereeEdge;
+  def.name = "Edge";
+  def.namespace_name = "Referee";
+  def.version = 1;
+
+  def.fields.push_back(FieldDefinition{ "from_id", kTypeObjectID, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "from_version", kTypeVersion, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "to_id", kTypeObjectID, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "to_version", kTypeVersion, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "name", kTypeString, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "role", kTypeString, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "props", kTypeBytes, false, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "created_at_ms", kTypeU64, true, std::nullopt });
+  return def;
+}
+
+TypeDefinition make_conch_session() {
+  TypeDefinition def;
+  def.type_id = kTypeConchSession;
+  def.name = "Session";
+  def.namespace_name = "Conch";
+  def.version = 1;
+
+  def.fields.push_back(FieldDefinition{ "name", kTypeString, false, std::nullopt });
+  return def;
+}
+
+TypeDefinition make_conch_concho() {
+  TypeDefinition def;
+  def.type_id = kTypeConchConcho;
+  def.name = "Concho";
+  def.namespace_name = "Conch";
+  def.version = 1;
+
+  def.fields.push_back(FieldDefinition{ "title", kTypeString, false, std::nullopt });
+  return def;
+}
+
+TypeDefinition make_viz_panel() {
+  TypeDefinition def;
+  def.type_id = kTypeVizPanel;
+  def.name = "Panel";
+  def.namespace_name = "Viz";
+  def.version = 1;
+  return def;
+}
+
+TypeDefinition make_viz_text_log() {
+  TypeDefinition def;
+  def.type_id = kTypeVizTextLog;
+  def.name = "TextLog";
+  def.namespace_name = "Viz";
+  def.version = 1;
+  return def;
+}
+
+TypeDefinition make_viz_metric() {
+  TypeDefinition def;
+  def.type_id = kTypeVizMetric;
+  def.name = "Metric";
+  def.namespace_name = "Viz";
+  def.version = 1;
+  return def;
+}
+
+TypeDefinition make_viz_table() {
+  TypeDefinition def;
+  def.type_id = kTypeVizTable;
+  def.name = "Table";
+  def.namespace_name = "Viz";
+  def.version = 1;
+  return def;
+}
+
+TypeDefinition make_viz_tree() {
+  TypeDefinition def;
+  def.type_id = kTypeVizTree;
+  def.name = "Tree";
+  def.namespace_name = "Viz";
+  def.version = 1;
+  return def;
+}
+
 } // namespace
 
 std::vector<TypeDefinition> core_schema_definitions() {
   std::vector<TypeDefinition> defs;
-  defs.reserve(8);
+  defs.reserve(20);
   defs.push_back(make_primitive(kTypeString, "String"));
   defs.push_back(make_primitive(kTypeU64, "U64"));
   defs.push_back(make_primitive(kTypeBool, "Bool"));
+  defs.push_back(make_primitive(kTypeObjectID, "ObjectID"));
+  defs.push_back(make_primitive(kTypeTypeID, "TypeID"));
+  defs.push_back(make_primitive(kTypeVersion, "Version"));
+  defs.push_back(make_primitive(kTypeBytes, "Bytes"));
   defs.push_back(make_type_definition());
   defs.push_back(make_field_definition());
   defs.push_back(make_signature_definition());
   defs.push_back(make_operation_definition());
   defs.push_back(make_relationship_spec());
+  defs.push_back(make_referee_object());
+  defs.push_back(make_referee_edge());
+  defs.push_back(make_conch_session());
+  defs.push_back(make_conch_concho());
+  defs.push_back(make_viz_panel());
+  defs.push_back(make_viz_text_log());
+  defs.push_back(make_viz_metric());
+  defs.push_back(make_viz_table());
+  defs.push_back(make_viz_tree());
   return defs;
 }
 


### PR DESCRIPTION
## Summary
- bootstrap core IrisOS types into Refract registry at Conch startup
- add Conch commands for define type/new/objects with JSON support

## Testing
- not run (not requested)