### PR TITLE
feat: add conch aliases for object references

### DIFF
--- a/docs/man/conch.1
+++ b/docs/man/conch.1
@@ -34,6 +34,22 @@ Filter namespaces using a regular expression.
 \fBobjects\fR
 List all object IDs in the store with their type names.
 .TP
+\fBlet\fR \fINAME\fR=\fIEXPR\fR
+Define a session alias. \fIEXPR\fR may be an ObjectID, another alias, or
+an inline \fBnew\fR expression.
+.TP
+\fBlet .\fR
+List session aliases.
+.TP
+\fBvar\fR \fINAME\fR=\fIEXPR\fR
+Define a persistent alias stored in Referee.
+.TP
+\fBvar .\fR
+List persistent aliases.
+.TP
+\fBalias\fR \fINAME\fR=\fIEXPR\fR
+Alias for \fBlet\fR.
+.TP
 \fBshow\fR \fIOBJECT_ID\fR
 Show object details and Refract schema metadata.
 .TP

--- a/src/refract/bootstrap.cc
+++ b/src/refract/bootstrap.cc
@@ -25,6 +25,7 @@ constexpr referee::TypeID kTypeRefereeEdge{0x5245464500000002ULL};
 
 constexpr referee::TypeID kTypeConchSession{0x434F4E4300000001ULL};
 constexpr referee::TypeID kTypeConchConcho{0x434F4E4300000002ULL};
+constexpr referee::TypeID kTypeConchAlias{0x434F4E4300000003ULL};
 
 constexpr referee::TypeID kTypeVizPanel{0x56495A0000000001ULL};
 constexpr referee::TypeID kTypeVizTextLog{0x56495A0000000002ULL};
@@ -164,6 +165,18 @@ TypeDefinition make_conch_concho() {
   return def;
 }
 
+TypeDefinition make_conch_alias() {
+  TypeDefinition def;
+  def.type_id = kTypeConchAlias;
+  def.name = "Alias";
+  def.namespace_name = "Conch";
+  def.version = 1;
+
+  def.fields.push_back(FieldDefinition{ "name", kTypeString, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "object_id", kTypeObjectID, true, std::nullopt });
+  return def;
+}
+
 TypeDefinition make_viz_panel() {
   TypeDefinition def;
   def.type_id = kTypeVizPanel;
@@ -230,6 +243,7 @@ std::vector<TypeDefinition> core_schema_definitions() {
   defs.push_back(make_referee_edge());
   defs.push_back(make_conch_session());
   defs.push_back(make_conch_concho());
+  defs.push_back(make_conch_alias());
   defs.push_back(make_viz_panel());
   defs.push_back(make_viz_text_log());
   defs.push_back(make_viz_metric());


### PR DESCRIPTION
## Summary
- add session and persistent aliases via let/var/alias
- allow @alias resolution in show/edges/call/start
- document aliases in conch man page
- register Conch::Alias type in bootstrap

## Testing
- not run (not requested)