### PR TITLE
fix: show prompt on blank lines

### DIFF
--- a/src/conch_shell/conch.cc
+++ b/src/conch_shell/conch.cc
@@ -1167,6 +1167,12 @@ int main(int argc, char** argv) {
     auto line_opt = read_line("conch> ");
     if (!line_opt.has_value()) break;
     const auto& line = line_opt.value();
+    if (line.empty()) {
+      if (::isatty(STDIN_FILENO)) {
+        std::cout << "\n";
+      }
+      continue;
+    }
     auto tokens = split_ws(line);
     if (tokens.empty()) continue;
 


### PR DESCRIPTION
Summary:
- Print a newline when the user submits an empty line so the prompt visibly refreshes.
- Avoid history changes by keeping readline behavior intact.

Validation:
- not run (user ran earlier)