### PR TITLE
docs: name parser ops collections math and units subsystems

### DIFF
--- a/docs/AR/accepted/AR-0015-Conch-Parser-and-Syntax.md
+++ b/docs/AR/accepted/AR-0015-Conch-Parser-and-Syntax.md
@@ -28,6 +28,10 @@ Define a standalone Conch parser class that converts a single input line into a 
 The parser is a dedicated component (not embedded in command handlers), with a small, explicit
 grammar and a deterministic tokenizer.
 
+### Naming
+
+Subsystem name: **Prism** (parser and tokenizer).
+
 ### Goals
 
 - Preserve existing commands and semantics.

--- a/docs/AR/proposed/AR-0016-Operations-Dispatch.md
+++ b/docs/AR/proposed/AR-0016-Operations-Dispatch.md
@@ -27,8 +27,7 @@ Define a formal Operations and Dispatch Model that:
 
 ### Naming
 
-Proposed subsystem name: **Dispatch** (preferred), or **Ops** if we want to keep it short.
-The name should emphasize resolution + invocation rather than storage.
+Subsystem name: **Conduit**.
 
 ## Concepts
 

--- a/docs/AR/proposed/AR-0017-Collections-Math-Units.md
+++ b/docs/AR/proposed/AR-0017-Collections-Math-Units.md
@@ -25,6 +25,12 @@ Expand Refract's core type system with:
 
 Treat these as first-class Refract types with definitions stored in the Refract registry.
 
+### Naming
+
+- Collections subsystem: **Crate**
+- Math subsystem: **Astra**
+- Units subsystem: **Caliper**
+
 ## Goals
 
 - Provide a common collection vocabulary usable by Conch and system services.
@@ -59,6 +65,17 @@ type parameterization in Refract (e.g., `List<String>`).
 - **Vector**: 1-D numeric collection (element type + length).
 - **Matrix**: 2-D numeric collection (element type + rows/cols).
 - **Tensor**: N-D numeric collection (element type + shape).
+
+### Quantities
+
+Define quantity types as first-class wrappers to combine values with constraints or units:
+
+- **Angle**
+- **Duration**
+- **Span**
+- **Range**
+- **Percentage**
+- **Ratio**
 
 ### Units of Measure
 


### PR DESCRIPTION
Summary:
- Name parser as Prism, operations as Conduit, collections as Crate, math as Astra, and units as Caliper.
- Add quantity types (Angle, Duration, Span, Range, Percentage, Ratio) to AR-0017.

Validation:
- not run (docs-only)