### PR TITLE
feat: add preferred renderer routing

### DIFF
--- a/src/refract/bootstrap.cc
+++ b/src/refract/bootstrap.cc
@@ -192,6 +192,7 @@ TypeDefinition make_viz_text_log() {
   def.name = "TextLog";
   def.namespace_name = "Viz";
   def.version = 1;
+  def.preferred_renderer = "Log";
   return def;
 }
 
@@ -201,6 +202,7 @@ TypeDefinition make_viz_metric() {
   def.name = "Metric";
   def.namespace_name = "Viz";
   def.version = 1;
+  def.preferred_renderer = "Metric";
   return def;
 }
 
@@ -210,6 +212,7 @@ TypeDefinition make_viz_table() {
   def.name = "Table";
   def.namespace_name = "Viz";
   def.version = 1;
+  def.preferred_renderer = "Table";
   return def;
 }
 
@@ -219,6 +222,7 @@ TypeDefinition make_viz_tree() {
   def.name = "Tree";
   def.namespace_name = "Viz";
   def.version = 1;
+  def.preferred_renderer = "Tree";
   return def;
 }
 

--- a/src/refract/schema_registry.cc
+++ b/src/refract/schema_registry.cc
@@ -52,6 +52,7 @@ static nlohmann::json to_json(const TypeDefinition& def) {
   j["name"] = def.name;
   j["namespace"] = def.namespace_name;
   j["version"] = def.version;
+  if (def.preferred_renderer.has_value()) j["preferred_renderer"] = def.preferred_renderer.value();
 
   j["fields"] = nlohmann::json::array();
   for (const auto& field : def.fields) j["fields"].push_back(to_json(field));
@@ -112,6 +113,9 @@ static TypeDefinition definition_from_json(const nlohmann::json& j) {
   def.name = j.value("name", "");
   def.namespace_name = j.value("namespace", "");
   def.version = j.value("version", 1ULL);
+  if (j.contains("preferred_renderer")) {
+    def.preferred_renderer = j.at("preferred_renderer").get<std::string>();
+  }
 
   if (j.contains("fields")) {
     for (const auto& item : j.at("fields")) def.fields.push_back(field_from_json(item));
@@ -226,6 +230,7 @@ referee::Result<std::vector<TypeSummary>> SchemaRegistry::list_types() {
     summary.definition_id = defR.value->ref.id;
     summary.name = defR.value->definition.name;
     summary.namespace_name = defR.value->definition.namespace_name;
+    summary.preferred_renderer = defR.value->definition.preferred_renderer;
 
     out.push_back(std::move(summary));
   }

--- a/src/refract/schema_registry.h
+++ b/src/refract/schema_registry.h
@@ -47,6 +47,7 @@ struct TypeDefinition {
   std::vector<FieldDefinition> fields;
   std::vector<OperationDefinition> operations;
   std::vector<RelationshipSpec> relationships;
+  std::optional<std::string> preferred_renderer;
 };
 
 struct TypeSummary {
@@ -54,6 +55,7 @@ struct TypeSummary {
   referee::ObjectID definition_id{};
   std::string name;
   std::string namespace_name;
+  std::optional<std::string> preferred_renderer;
 };
 
 struct DefinitionRecord {

--- a/src/vizier/routing.cc
+++ b/src/vizier/routing.cc
@@ -8,6 +8,9 @@ static std::string display_name(const iris::refract::TypeSummary& summary) {
 }
 
 std::optional<Route> route_for_type(const iris::refract::TypeSummary& summary) {
+  if (summary.preferred_renderer.has_value() && !summary.preferred_renderer->empty()) {
+    return Route{summary.preferred_renderer.value()};
+  }
   auto full = display_name(summary);
   if (full == "Viz::TextLog") return Route{"Log"};
   if (full == "Viz::Metric") return Route{"Metric"};

--- a/tests/test_vizier_routing.cc
+++ b/tests/test_vizier_routing.cc
@@ -31,12 +31,23 @@ START_TEST(test_unknown_route)
 }
 END_TEST
 
+START_TEST(test_preferred_renderer_route)
+{
+  TypeSummary custom{referee::TypeID{6}, referee::ObjectID{}, "Widget", "Demo"};
+  custom.preferred_renderer = "Panel";
+  auto route = route_for_type(custom);
+  ck_assert(route.has_value());
+  ck_assert_str_eq(route->concho.c_str(), "Panel");
+}
+END_TEST
+
 Suite* vizier_routing_suite(void) {
   Suite* s = suite_create("VizierRouting");
   TCase* tc = tcase_create("core");
 
   tcase_add_test(tc, test_viz_routes);
   tcase_add_test(tc, test_unknown_route);
+  tcase_add_test(tc, test_preferred_renderer_route);
 
   suite_add_tcase(s, tc);
   return s;


### PR DESCRIPTION
## Summary
- add preferred renderer metadata to Refract definitions and summaries
- route via preferred renderer when present, with tests
- set preferred renderer for Viz artifact types

## Testing
- make check (fails: ./config.status missing)