### PR TITLE
feat: auto-spawn conchos for viz artifacts

### DIFF
--- a/src/conch_shell/conch.cc
+++ b/src/conch_shell/conch.cc
@@ -1244,6 +1244,21 @@ void print_route_for(iris::refract::SchemaRegistry& registry, referee::TypeID ty
   std::cout << "route: " << routeR->concho << "\n";
 }
 
+void maybe_spawn_concho(iris::refract::SchemaRegistry& registry,
+                        referee::SqliteStore& store,
+                        const referee::ObjectID& artifact_id) {
+  auto conchoR = iris::vizier::spawn_concho_for_artifact(registry, store, artifact_id);
+  if (!conchoR) {
+    std::cout << "error: " << conchoR.error->message << "\n";
+    return;
+  }
+  if (!conchoR.value->has_value()) {
+    std::cout << "concho: none\n";
+    return;
+  }
+  std::cout << "concho: " << conchoR.value->value().to_hex() << "\n";
+}
+
 void cmd_emit_viz(SchemaRegistry& registry, SqliteStore& store,
                   const std::unordered_map<std::string, ObjectID>& session_aliases,
                   const std::vector<std::string>& tokens) {
@@ -1274,6 +1289,7 @@ void cmd_emit_viz(SchemaRegistry& registry, SqliteStore& store,
     auto id = idR.value.value();
     std::cout << "created Viz::TextLog " << id.to_hex() << "\n";
     print_route_for(registry, iris::viz::kTypeVizTextLog);
+    maybe_spawn_concho(registry, store, id);
     if (flags.produced_by.has_value()) {
       auto from_id = parse_object_id_or_alias(flags.produced_by.value(), session_aliases,
                                               store, registry, &err);
@@ -1321,6 +1337,7 @@ void cmd_emit_viz(SchemaRegistry& registry, SqliteStore& store,
     auto id = idR.value.value();
     std::cout << "created Viz::Metric " << id.to_hex() << "\n";
     print_route_for(registry, iris::viz::kTypeVizMetric);
+    maybe_spawn_concho(registry, store, id);
     if (flags.produced_by.has_value()) {
       auto from_id = parse_object_id_or_alias(flags.produced_by.value(), session_aliases,
                                               store, registry, &err);
@@ -1359,6 +1376,7 @@ void cmd_emit_viz(SchemaRegistry& registry, SqliteStore& store,
     auto id = idR.value.value();
     std::cout << "created Viz::Table " << id.to_hex() << "\n";
     print_route_for(registry, iris::viz::kTypeVizTable);
+    maybe_spawn_concho(registry, store, id);
     if (flags.produced_by.has_value()) {
       auto from_id = parse_object_id_or_alias(flags.produced_by.value(), session_aliases,
                                               store, registry, &err);
@@ -1396,6 +1414,7 @@ void cmd_emit_viz(SchemaRegistry& registry, SqliteStore& store,
     auto id = idR.value.value();
     std::cout << "created Viz::Tree " << id.to_hex() << "\n";
     print_route_for(registry, iris::viz::kTypeVizTree);
+    maybe_spawn_concho(registry, store, id);
     if (flags.produced_by.has_value()) {
       auto from_id = parse_object_id_or_alias(flags.produced_by.value(), session_aliases,
                                               store, registry, &err);
@@ -1433,6 +1452,7 @@ void cmd_emit_viz(SchemaRegistry& registry, SqliteStore& store,
     auto id = idR.value.value();
     std::cout << "created Viz::Panel " << id.to_hex() << "\n";
     print_route_for(registry, iris::viz::kTypeVizPanel);
+    maybe_spawn_concho(registry, store, id);
     if (flags.produced_by.has_value()) {
       auto from_id = parse_object_id_or_alias(flags.produced_by.value(), session_aliases,
                                               store, registry, &err);
@@ -1488,6 +1508,9 @@ void cmd_edge(SqliteStore& store, SchemaRegistry& registry,
     return;
   }
   std::cout << "edge added\n";
+  if (name == "produced" || name == "progress" || name == "diagnostic") {
+    maybe_spawn_concho(registry, store, to_id.value());
+  }
 }
 
 void cmd_route_type(SchemaRegistry& registry, const std::string& type_name) {

--- a/src/vizier/routing.cc
+++ b/src/vizier/routing.cc
@@ -1,5 +1,7 @@
 #include "vizier/routing.h"
 
+#include <nlohmann/json.hpp>
+
 namespace iris::vizier {
 
 static std::string display_name(const iris::refract::TypeSummary& summary) {
@@ -28,6 +30,54 @@ std::optional<Route> route_for_type_id(iris::refract::SchemaRegistry& registry,
     if (summary.type_id == type_id) return route_for_type(summary);
   }
   return std::nullopt;
+}
+
+referee::Result<std::optional<referee::ObjectID>> spawn_concho_for_artifact(
+    iris::refract::SchemaRegistry& registry,
+    referee::SqliteStore& store,
+    referee::ObjectID artifact_id) {
+  auto recR = store.get_latest(artifact_id);
+  if (!recR) return referee::Result<std::optional<referee::ObjectID>>::err(recR.error->message);
+  if (!recR.value->has_value()) {
+    return referee::Result<std::optional<referee::ObjectID>>::err("artifact not found");
+  }
+
+  auto route = route_for_type_id(registry, recR.value->value().type);
+  if (!route.has_value()) {
+    return referee::Result<std::optional<referee::ObjectID>>::ok(
+        std::optional<referee::ObjectID>{});
+  }
+
+  auto typesR = registry.list_types();
+  if (!typesR) {
+    return referee::Result<std::optional<referee::ObjectID>>::err(typesR.error->message);
+  }
+  std::optional<iris::refract::TypeSummary> concho_type;
+  for (const auto& summary : typesR.value.value()) {
+    if (summary.namespace_name == "Conch" && summary.name == "Concho") {
+      concho_type = summary;
+      break;
+    }
+  }
+  if (!concho_type.has_value()) {
+    return referee::Result<std::optional<referee::ObjectID>>::err("Conch::Concho type not registered");
+  }
+
+  nlohmann::json payload;
+  payload["title"] = route->concho;
+  auto cbor = nlohmann::json::to_cbor(payload);
+  auto createR = store.create_object(concho_type->type_id, concho_type->definition_id, cbor);
+  if (!createR) {
+    return referee::Result<std::optional<referee::ObjectID>>::err(createR.error->message);
+  }
+
+  referee::Bytes props;
+  auto edgeR = store.add_edge(recR.value->value().ref, createR.value->ref, "view", "concho", props);
+  if (!edgeR) {
+    return referee::Result<std::optional<referee::ObjectID>>::err(edgeR.error->message);
+  }
+
+  return referee::Result<std::optional<referee::ObjectID>>::ok(createR.value->ref.id);
 }
 
 } // namespace iris::vizier

--- a/src/vizier/routing.h
+++ b/src/vizier/routing.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "refract/schema_registry.h"
+#include "referee_sqlite/sqlite_store.h"
 
 #include <optional>
 #include <string>
@@ -14,5 +15,9 @@ struct Route {
 std::optional<Route> route_for_type(const iris::refract::TypeSummary& summary);
 std::optional<Route> route_for_type_id(iris::refract::SchemaRegistry& registry,
                                        referee::TypeID type_id);
+referee::Result<std::optional<referee::ObjectID>> spawn_concho_for_artifact(
+    iris::refract::SchemaRegistry& registry,
+    referee::SqliteStore& store,
+    referee::ObjectID artifact_id);
 
 } // namespace iris::vizier

--- a/tests/test_phase3_integration.cc
+++ b/tests/test_phase3_integration.cc
@@ -12,6 +12,8 @@ extern "C" {
 #include "viz/artifacts.h"
 #include "vizier/routing.h"
 
+#include <optional>
+
 using namespace referee;
 using namespace iris::refract;
 using namespace iris::viz;
@@ -22,6 +24,19 @@ namespace {
 template <typename T>
 const char* result_message(const Result<T>& r) {
   return r.error.has_value() ? r.error->message.c_str() : "ok";
+}
+
+std::optional<TypeID> find_type_id(SchemaRegistry& registry,
+                                   const std::string& ns,
+                                   const std::string& name) {
+  auto listR = registry.list_types();
+  if (!listR) return std::nullopt;
+  for (const auto& summary : listR.value.value()) {
+    if (summary.namespace_name == ns && summary.name == name) {
+      return summary.type_id;
+    }
+  }
+  return std::nullopt;
 }
 
 } // namespace
@@ -53,11 +68,57 @@ START_TEST(test_phase3_artifact_route)
 }
 END_TEST
 
+START_TEST(test_phase3_concho_spawn)
+{
+  SqliteStore store(SqliteConfig{ .filename=":memory:", .enable_wal=false });
+  ck_assert_msg(store.open(), "open failed");
+  ck_assert_msg(store.ensure_schema(), "ensure_schema failed");
+
+  SchemaRegistry registry(store);
+  auto boot = bootstrap_core_schema(registry);
+  ck_assert_msg(boot, "bootstrap failed: %s", result_message(boot));
+
+  TextLog log;
+  log.lines = {"hello"};
+  auto logR = create_text_log(registry, store, log);
+  ck_assert_msg(logR, "create_text_log failed: %s", result_message(logR));
+
+  auto conchoR = spawn_concho_for_artifact(registry, store, logR.value.value());
+  ck_assert_msg(conchoR, "spawn_concho_for_artifact failed: %s", result_message(conchoR));
+  ck_assert_msg(conchoR.value->has_value(), "expected concho spawn");
+
+  auto conchoRecR = store.get_latest(conchoR.value->value());
+  ck_assert_msg(conchoRecR, "get_latest concho failed: %s", result_message(conchoRecR));
+  ck_assert_msg(conchoRecR.value->has_value(), "expected concho record");
+  auto conchoType = find_type_id(registry, "Conch", "Concho");
+  ck_assert_msg(conchoType.has_value(), "expected Conch::Concho type");
+  ck_assert_uint_eq(conchoRecR.value->value().type.v, conchoType->v);
+
+  auto logRecR = store.get_latest(logR.value.value());
+  ck_assert_msg(logRecR, "get_latest log failed: %s", result_message(logRecR));
+  ck_assert_msg(logRecR.value->has_value(), "expected log record");
+  auto edgesR = store.edges_from(logRecR.value->value().ref);
+  ck_assert_msg(edgesR, "edges_from failed: %s", result_message(edgesR));
+  bool found = false;
+  for (const auto& edge : edgesR.value.value()) {
+    if (edge.name == "view" && edge.role == "concho"
+        && edge.to.id.to_hex() == conchoR.value->value().to_hex()) {
+      found = true;
+      break;
+    }
+  }
+  ck_assert_msg(found, "expected view->concho edge");
+
+  ck_assert_msg(store.close(), "close failed");
+}
+END_TEST
+
 Suite* phase3_integration_suite(void) {
   Suite* s = suite_create("Phase3Integration");
   TCase* tc = tcase_create("core");
 
   tcase_add_test(tc, test_phase3_artifact_route);
+  tcase_add_test(tc, test_phase3_concho_spawn);
 
   suite_add_tcase(s, tc);
   return s;


### PR DESCRIPTION
## Summary
- add a vizier helper to spawn Conch::Concho objects for routed artifacts
- auto-spawn conchos when artifacts are emitted or edges are added in Conch
- add Phase 3 integration test for concho spawning and view edge

## Testing
- not run (local make check fails: ./config.status missing)