### PR TITLE
feat: implement phase4 demo flow

### DIFF
--- a/scripts/demo_phase4.sh
+++ b/scripts/demo_phase4.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+db_path="${1:-/tmp/iris_demo.db}"
+rm -f "${db_path}" "${db_path}-shm" "${db_path}-wal"
+
+output=$(printf "let demo=new Demo::PropulsionSynth name:=PropulsionSynth\nstart demo\nexit\n" | ./bin/conch --db "${db_path}")
+summary_id=$(printf "%s\n" "${output}" | awk '/^summary / {print $2; exit}')
+
+echo "${output}"
+
+if [[ -z "${summary_id}" ]]; then
+  echo "error: failed to extract demo summary id" >&2
+  exit 1
+fi
+
+printf "call %s expand 1\nexit\n" "${summary_id}" | ./bin/conch --db "${db_path}"

--- a/src/refract/bootstrap.cc
+++ b/src/refract/bootstrap.cc
@@ -34,6 +34,10 @@ constexpr referee::TypeID kTypeVizMetric{0x56495A0000000003ULL};
 constexpr referee::TypeID kTypeVizTable{0x56495A0000000004ULL};
 constexpr referee::TypeID kTypeVizTree{0x56495A0000000005ULL};
 
+constexpr referee::TypeID kTypeDemoPropulsionSynth{0x44454D4F00000001ULL};
+constexpr referee::TypeID kTypeDemoSummary{0x44454D4F00000002ULL};
+constexpr referee::TypeID kTypeDemoDetail{0x44454D4F00000003ULL};
+
 referee::ObjectID definition_id_for(referee::TypeID type_id) {
   referee::ObjectID id{};
   std::array<std::uint8_t, 8> tag = { 'R','E','F','R','A','C','T','0' };
@@ -235,11 +239,60 @@ TypeDefinition make_viz_tree() {
   return def;
 }
 
+TypeDefinition make_demo_propulsion_synth() {
+  TypeDefinition def;
+  def.type_id = kTypeDemoPropulsionSynth;
+  def.name = "PropulsionSynth";
+  def.namespace_name = "Demo";
+  def.version = 1;
+
+  def.fields.push_back(FieldDefinition{ "name", kTypeString, false, std::nullopt });
+
+  OperationDefinition start_op;
+  start_op.name = "start";
+  def.operations.push_back(std::move(start_op));
+
+  def.relationships.push_back(RelationshipSpec{ "summary", "one", "Demo::Summary" });
+  return def;
+}
+
+TypeDefinition make_demo_summary() {
+  TypeDefinition def;
+  def.type_id = kTypeDemoSummary;
+  def.name = "Summary";
+  def.namespace_name = "Demo";
+  def.version = 1;
+
+  def.fields.push_back(FieldDefinition{ "title", kTypeString, false, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "level", kTypeU64, false, std::nullopt });
+
+  OperationDefinition expand_op;
+  expand_op.name = "expand";
+  expand_op.signature.params.push_back(ParameterDefinition{ "level", kTypeU64, true });
+  def.operations.push_back(std::move(expand_op));
+
+  def.relationships.push_back(RelationshipSpec{ "detail", "many", "Demo::Detail" });
+  return def;
+}
+
+TypeDefinition make_demo_detail() {
+  TypeDefinition def;
+  def.type_id = kTypeDemoDetail;
+  def.name = "Detail";
+  def.namespace_name = "Demo";
+  def.version = 1;
+
+  def.fields.push_back(FieldDefinition{ "title", kTypeString, false, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "level", kTypeU64, false, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "index", kTypeU64, false, std::nullopt });
+  return def;
+}
+
 } // namespace
 
 std::vector<TypeDefinition> core_schema_definitions() {
   std::vector<TypeDefinition> defs;
-  defs.reserve(21);
+  defs.reserve(24);
   defs.push_back(make_primitive(kTypeString, "String"));
   defs.push_back(make_primitive(kTypeU64, "U64"));
   defs.push_back(make_primitive(kTypeBool, "Bool"));
@@ -263,6 +316,9 @@ std::vector<TypeDefinition> core_schema_definitions() {
   defs.push_back(make_viz_metric());
   defs.push_back(make_viz_table());
   defs.push_back(make_viz_tree());
+  defs.push_back(make_demo_propulsion_synth());
+  defs.push_back(make_demo_summary());
+  defs.push_back(make_demo_detail());
   return defs;
 }
 

--- a/tests/test_phase3_integration.cc
+++ b/tests/test_phase3_integration.cc
@@ -39,6 +39,19 @@ std::optional<TypeID> find_type_id(SchemaRegistry& registry,
   return std::nullopt;
 }
 
+std::optional<TypeSummary> find_type_summary(SchemaRegistry& registry,
+                                             const std::string& ns,
+                                             const std::string& name) {
+  auto listR = registry.list_types();
+  if (!listR) return std::nullopt;
+  for (const auto& summary : listR.value.value()) {
+    if (summary.namespace_name == ns && summary.name == name) {
+      return summary;
+    }
+  }
+  return std::nullopt;
+}
+
 } // namespace
 
 START_TEST(test_phase3_artifact_route)
@@ -113,12 +126,104 @@ START_TEST(test_phase3_concho_spawn)
 }
 END_TEST
 
+START_TEST(test_phase4_demo_schema)
+{
+  SqliteStore store(SqliteConfig{ .filename=":memory:", .enable_wal=false });
+  ck_assert_msg(store.open(), "open failed");
+  ck_assert_msg(store.ensure_schema(), "ensure_schema failed");
+
+  SchemaRegistry registry(store);
+  auto boot = bootstrap_core_schema(registry);
+  ck_assert_msg(boot, "bootstrap failed: %s", result_message(boot));
+
+  auto demo = find_type_summary(registry, "Demo", "PropulsionSynth");
+  ck_assert_msg(demo.has_value(), "expected Demo::PropulsionSynth type");
+  auto summary = find_type_summary(registry, "Demo", "Summary");
+  ck_assert_msg(summary.has_value(), "expected Demo::Summary type");
+  auto detail = find_type_summary(registry, "Demo", "Detail");
+  ck_assert_msg(detail.has_value(), "expected Demo::Detail type");
+
+  auto demoDefR = registry.get_definition_by_type(demo->type_id);
+  ck_assert_msg(demoDefR, "get_definition_by_type demo failed: %s", result_message(demoDefR));
+  bool start_found = false;
+  for (const auto& op : demoDefR.value->value().definition.operations) {
+    if (op.name == "start") start_found = true;
+  }
+  ck_assert_msg(start_found, "expected start operation on Demo::PropulsionSynth");
+
+  auto summaryDefR = registry.get_definition_by_type(summary->type_id);
+  ck_assert_msg(summaryDefR, "get_definition_by_type summary failed: %s", result_message(summaryDefR));
+  bool expand_found = false;
+  for (const auto& op : summaryDefR.value->value().definition.operations) {
+    if (op.name == "expand") {
+      expand_found = true;
+      ck_assert_int_eq((int)op.signature.params.size(), 1);
+      ck_assert_str_eq(op.signature.params[0].name.c_str(), "level");
+      ck_assert_msg(op.signature.params[0].optional, "expected optional level param");
+    }
+  }
+  ck_assert_msg(expand_found, "expected expand operation on Demo::Summary");
+
+  auto detailDefR = registry.get_definition_by_type(detail->type_id);
+  ck_assert_msg(detailDefR, "get_definition_by_type detail failed: %s", result_message(detailDefR));
+  bool has_title = false;
+  bool has_level = false;
+  bool has_index = false;
+  for (const auto& field : detailDefR.value->value().definition.fields) {
+    if (field.name == "title") has_title = true;
+    if (field.name == "level") has_level = true;
+    if (field.name == "index") has_index = true;
+  }
+  ck_assert_msg(has_title && has_level && has_index, "expected title/level/index fields on Demo::Detail");
+
+  auto demo_payload = referee::cbor_from_json_string("{\"name\":\"Demo\"}");
+  auto demoR = store.create_object(demo->type_id, demo->definition_id, demo_payload);
+  ck_assert_msg(demoR, "create demo failed: %s", result_message(demoR));
+
+  auto summary_payload = referee::cbor_from_json_string("{\"title\":\"Summary\",\"level\":0}");
+  auto summaryR = store.create_object(summary->type_id, summary->definition_id, summary_payload);
+  ck_assert_msg(summaryR, "create summary failed: %s", result_message(summaryR));
+
+  auto detail_payload = referee::cbor_from_json_string("{\"title\":\"Detail\",\"level\":1,\"index\":1}");
+  auto detailR = store.create_object(detail->type_id, detail->definition_id, detail_payload);
+  ck_assert_msg(detailR, "create detail failed: %s", result_message(detailR));
+
+  referee::Bytes props;
+  auto edgeDemoR = store.add_edge(demoR.value->ref, summaryR.value->ref, "summary", "root", props);
+  ck_assert_msg(edgeDemoR, "add_edge summary failed: %s", result_message(edgeDemoR));
+
+  auto edgeR = store.add_edge(summaryR.value->ref, detailR.value->ref, "summarizes", "detail", props);
+  ck_assert_msg(edgeR, "add_edge failed: %s", result_message(edgeR));
+
+  Metric metric;
+  metric.name = "thrust";
+  metric.value = 0.7;
+  auto metricR = create_metric(registry, store, metric);
+  ck_assert_msg(metricR, "create_metric failed: %s", result_message(metricR));
+
+  auto metricRecR = store.get_latest(metricR.value.value());
+  ck_assert_msg(metricRecR, "get_latest metric failed: %s", result_message(metricRecR));
+  ck_assert_msg(metricRecR.value->has_value(), "expected metric record");
+
+  auto edgeR2 = store.add_edge(detailR.value->ref, metricRecR.value->value().ref,
+                               "produced", "artifact", props);
+  ck_assert_msg(edgeR2, "add_edge metric failed: %s", result_message(edgeR2));
+
+  auto conchoR = spawn_concho_for_artifact(registry, store, metricR.value.value());
+  ck_assert_msg(conchoR, "spawn_concho_for_artifact failed: %s", result_message(conchoR));
+  ck_assert_msg(conchoR.value->has_value(), "expected concho for demo artifact");
+
+  ck_assert_msg(store.close(), "close failed");
+}
+END_TEST
+
 Suite* phase3_integration_suite(void) {
   Suite* s = suite_create("Phase3Integration");
   TCase* tc = tcase_create("core");
 
   tcase_add_test(tc, test_phase3_artifact_route);
   tcase_add_test(tc, test_phase3_concho_spawn);
+  tcase_add_test(tc, test_phase4_demo_schema);
 
   suite_add_tcase(s, tc);
   return s;


### PR DESCRIPTION
## Summary
- add Demo schema types and operations for PropulsionSynth, Summary, Detail
- implement demo start/expand artifact emission in Conch plus demo script
- add Phase 4 smoke coverage to the integration tests

## Testing
- Not run (not requested)
