### PR TITLE
feat: implement conduit operation model

### DIFF
--- a/docs/ER/ER-0028-Conduit-Operation-Model.md
+++ b/docs/ER/ER-0028-Conduit-Operation-Model.md
@@ -15,8 +15,8 @@ GitHub-Issue: #109
 
 - ER ID: ER-0028
 - Title: Conduit Operation Model
-- Status: Proposed
-- Date: 2026-02-21
+- Status: Implemented
+- Date: 2026-02-25
 - Owners: Mike
 - Type: Epic
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,6 +37,8 @@ libreferee_la_SOURCES = \
    services/service.cc \
    refract/bootstrap.h \
    refract/bootstrap.cc \
+   refract/operation_registry.h \
+   refract/operation_registry.cc \
    refract/schema_registry.h \
    refract/schema_registry.cc \
    referee_sqlite/sqlite_store.h \
@@ -47,6 +49,7 @@ libreferee_la_LIBADD = $(SQLITE_LIBS)
 
 include_HEADERS = referee/referee.h \
    services/service.h \
+   refract/operation_registry.h \
    refract/schema_registry.h \
    ceo/task_registry.h \
    ceo/io_reactor.h \

--- a/src/conch_shell/conch.cc
+++ b/src/conch_shell/conch.cc
@@ -918,8 +918,20 @@ void cmd_show_type(SchemaRegistry& registry, const std::string& name) {
         if (param.optional) std::cout << "?";
       }
       std::cout << ")";
-      if (op.signature.return_type.has_value()) {
-        std::cout << " -> 0x" << std::hex << op.signature.return_type->v << std::dec;
+      if (!op.signature.outputs.empty()) {
+        std::cout << " -> ";
+        if (op.signature.outputs.size() > 1) std::cout << "(";
+        for (size_t i = 0; i < op.signature.outputs.size(); ++i) {
+          if (i > 0) std::cout << ", ";
+          const auto& out = op.signature.outputs[i];
+          if (!out.name.empty()) {
+            std::cout << out.name;
+          } else {
+            std::cout << "result";
+          }
+          if (out.optional) std::cout << "?";
+        }
+        if (op.signature.outputs.size() > 1) std::cout << ")";
       }
       std::cout << "\n";
     }
@@ -982,8 +994,20 @@ void cmd_show(SchemaRegistry& registry, SqliteStore& store, const ObjectID& id) 
         if (param.optional) std::cout << "?";
       }
       std::cout << ")";
-      if (op.signature.return_type.has_value()) {
-        std::cout << " -> 0x" << std::hex << op.signature.return_type->v << std::dec;
+      if (!op.signature.outputs.empty()) {
+        std::cout << " -> ";
+        if (op.signature.outputs.size() > 1) std::cout << "(";
+        for (size_t i = 0; i < op.signature.outputs.size(); ++i) {
+          if (i > 0) std::cout << ", ";
+          const auto& out = op.signature.outputs[i];
+          if (!out.name.empty()) {
+            std::cout << out.name;
+          } else {
+            std::cout << "result";
+          }
+          if (out.optional) std::cout << "?";
+        }
+        if (op.signature.outputs.size() > 1) std::cout << ")";
       }
       std::cout << "\n";
     }

--- a/src/refract/bootstrap.cc
+++ b/src/refract/bootstrap.cc
@@ -93,6 +93,8 @@ TypeDefinition make_signature_definition() {
   def.name = "SignatureDefinition";
   def.namespace_name = "Refract";
   def.version = 1;
+  def.fields.push_back(FieldDefinition{ "params", kTypeBytes, false, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "outputs", kTypeBytes, false, std::nullopt });
   return def;
 }
 
@@ -102,6 +104,9 @@ TypeDefinition make_operation_definition() {
   def.name = "OperationDefinition";
   def.namespace_name = "Refract";
   def.version = 1;
+  def.fields.push_back(FieldDefinition{ "name", kTypeString, true, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "scope", kTypeString, false, std::nullopt });
+  def.fields.push_back(FieldDefinition{ "signature", kTypeBytes, false, std::nullopt });
   return def;
 }
 
@@ -250,6 +255,7 @@ TypeDefinition make_demo_propulsion_synth() {
 
   OperationDefinition start_op;
   start_op.name = "start";
+  start_op.scope = OperationScope::Object;
   def.operations.push_back(std::move(start_op));
 
   def.relationships.push_back(RelationshipSpec{ "summary", "one", "Demo::Summary" });
@@ -268,6 +274,7 @@ TypeDefinition make_demo_summary() {
 
   OperationDefinition expand_op;
   expand_op.name = "expand";
+  expand_op.scope = OperationScope::Object;
   expand_op.signature.params.push_back(ParameterDefinition{ "level", kTypeU64, true });
   def.operations.push_back(std::move(expand_op));
 

--- a/src/refract/operation_registry.cc
+++ b/src/refract/operation_registry.cc
@@ -1,0 +1,52 @@
+#include "refract/operation_registry.h"
+
+#include <cstdint>
+#include <deque>
+#include <unordered_set>
+
+namespace iris::refract {
+
+OperationRegistry::OperationRegistry(SchemaRegistry& registry,
+                                     InheritanceResolver resolver)
+  : registry_(registry),
+    resolver_(std::move(resolver)) {}
+
+referee::Result<std::vector<OperationDefinition>> OperationRegistry::list_operations(
+    referee::TypeID type,
+    OperationScope scope,
+    bool include_inherited) {
+  std::vector<OperationDefinition> out;
+  std::deque<referee::TypeID> queue;
+  std::unordered_set<std::uint64_t> visited;
+
+  queue.push_back(type);
+  visited.insert(type.v);
+
+  while (!queue.empty()) {
+    auto current = queue.front();
+    queue.pop_front();
+
+    auto defR = registry_.get_latest_definition_by_type(current);
+    if (!defR) return referee::Result<std::vector<OperationDefinition>>::err(defR.error->message);
+    if (!defR.value->has_value()) {
+      return referee::Result<std::vector<OperationDefinition>>::err("definition not found");
+    }
+
+    const auto& def = defR.value->value().definition;
+    for (const auto& op : def.operations) {
+      if (op.scope == scope) out.push_back(op);
+    }
+
+    if (include_inherited && resolver_) {
+      for (const auto& base : resolver_(current)) {
+        if (visited.insert(base.v).second) {
+          queue.push_back(base);
+        }
+      }
+    }
+  }
+
+  return referee::Result<std::vector<OperationDefinition>>::ok(std::move(out));
+}
+
+} // namespace iris::refract

--- a/src/refract/operation_registry.h
+++ b/src/refract/operation_registry.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "refract/schema_registry.h"
+
+#include <functional>
+#include <vector>
+
+namespace iris::refract {
+
+class OperationRegistry {
+public:
+  using InheritanceResolver = std::function<std::vector<referee::TypeID>(referee::TypeID)>;
+
+  explicit OperationRegistry(SchemaRegistry& registry,
+                             InheritanceResolver resolver = {});
+
+  referee::Result<std::vector<OperationDefinition>> list_operations(
+      referee::TypeID type,
+      OperationScope scope,
+      bool include_inherited = true);
+
+private:
+  SchemaRegistry& registry_;
+  InheritanceResolver resolver_;
+};
+
+} // namespace iris::refract

--- a/src/refract/schema_registry.h
+++ b/src/refract/schema_registry.h
@@ -25,11 +25,17 @@ struct ParameterDefinition {
 
 struct SignatureDefinition {
   std::vector<ParameterDefinition> params;
-  std::optional<referee::TypeID> return_type;
+  std::vector<ParameterDefinition> outputs;
+};
+
+enum class OperationScope {
+  Class,
+  Object
 };
 
 struct OperationDefinition {
   std::string name;
+  OperationScope scope{OperationScope::Object};
   SignatureDefinition signature;
 };
 


### PR DESCRIPTION
Summary:\n- add operation scope and ordered outputs to Refract operation/signature schema\n- add Conduit operation registry with inherited lookup support\n- update Conch op display and Refract bootstrap schema fields\n- update ER-0028 status to Implemented\n\nTests:\n- make check TESTS="test_refract_registry"\n