### PR TITLE
feat: integrate conduit dispatch in conch

### DIFF
--- a/docs/ER/ER-0029-Conduit-Dispatch-Engine.md
+++ b/docs/ER/ER-0029-Conduit-Dispatch-Engine.md
@@ -15,7 +15,7 @@ GitHub-Issue: #110
 
 - ER ID: ER-0029
 - Title: Conduit Dispatch Engine
-- Status: Implemented
+- Status: Verified
 - Date: 2026-02-25
 - Owners: Mike
 - Type: Enhancement

--- a/docs/ER/ER-0030-Conduit-Conch-Integration.md
+++ b/docs/ER/ER-0030-Conduit-Conch-Integration.md
@@ -15,8 +15,8 @@ GitHub-Issue: #111
 
 - ER ID: ER-0030
 - Title: Conduit Conch Integration
-- Status: Proposed
-- Date: 2026-02-21
+- Status: Implemented
+- Date: 2026-02-25
 - Owners: Mike
 - Type: Enhancement
 


### PR DESCRIPTION
Summary:\n- add Conch ops listing with scope and inheritance\n- group show type operations by scope/overload and include inherited entries\n- mark ER-0029 Verified and ER-0030 Implemented\n\nTests:\n- make check TESTS="test_refract_registry"\n