### PR TITLE
docs: add v1 and v2 implementation plans

### DIFF
--- a/docs/Plan/AR0014-AR0021-Implementation-Plan.md
+++ b/docs/Plan/AR0014-AR0021-Implementation-Plan.md
@@ -1,0 +1,170 @@
+# Implementation Plan: AR-0014 through AR-0021 (v1)
+
+- Status: Draft
+- Date: 2026-02-27
+- Owners: Mike
+
+## Scope
+
+This plan defines the v1 build, focused on persistence correctness and a viable kernel-grade
+foundation. It treats the v0 plan as complete and builds on the accepted/proposed ARs up through
+AR-0021. ER-0021 through ER-0033 are mapped into v1 or v2 as noted below.
+
+## Guiding Principles
+
+- Make persistence correct and durable before expanding userland scope.
+- Promote Refract-native schemas and structured types to first-class status.
+- Ensure the kernel and core libraries use the same operation/dispatch model.
+- Keep the kernel core small and deterministic; defer utilities to v2.
+
+---
+
+## Phase 1 — Persistence and Storage Hardening
+
+### Features
+
+- Align Referee storage with AR-0003/AR-0004 beyond SQLite.
+- Define durable on-disk layout, indexes, and recovery strategy.
+- Formalize Definition versioning + migration hooks.
+
+### Milestones
+
+- M1.1: Storage layout selected and implemented (segment/index or equivalent).
+- M1.2: Recovery and rebuild workflows validated.
+
+### ERs
+
+- ER-0018 Phase6 Storage Alignment (Verified)
+- ER-0019 Phase6 Persistence Tests (Verified)
+- ER-0020 Phase6 Integration (Verified)
+
+### Tests
+
+- Persistence across restart and crash recovery.
+- Definition migration tests for versioned schemas.
+
+---
+
+## Phase 2 — Refract-Native Schemas and Structured Types
+
+### Features
+
+- Move schemas from dual representation to Refract-native storage as the source of truth.
+- Implement Structured Types per AR-0021 (Struct/Packet/Enum) with validation + serialization.
+- Make arrays of structured types first-class in Refract.
+
+### Milestones
+
+- M2.1: Refract-native schema registry is authoritative.
+- M2.2: Struct/Packet/Enum definitions can be created, stored, and introspected.
+
+### ERs
+
+- ER-0021 Conch Schema and Object Authoring (Verified)
+- ER-0031 Crate Collections (Verified)
+- ER-0032 Astra Math Types (Verified)
+- ER-0033 Caliper Units and Quantities (Verified)
+
+### Tests
+
+- Definition creation and lookup for structured types.
+- Serialization round-trip tests for structs and packets.
+
+---
+
+## Phase 3 — Generics and Type Identity
+
+### Features
+
+- Implement AR-0018 generic type system with explicit TypeID encoding.
+- Scoped type registries for caching generic instantiations.
+- Deterministic instantiation validation and introspection.
+
+### Milestones
+
+- M3.1: GenericInstance schema and TypeID encoding implemented.
+- M3.2: Scoped registry behaviors validated.
+
+### Tests
+
+- Generic instantiation determinism tests.
+- TypeID stability tests across processes.
+
+---
+
+## Phase 4 — Core Operations and Dispatch Integration
+
+### Features
+
+- Implement AR-0020 core operations (`to_string`, `print`, `render`, compare semantics).
+- Implement Conduit operation registry and dispatch per AR-0016/ER-0028..0030.
+- Bind operations to implementations across core types and structured types.
+
+### Milestones
+
+- M4.1: Core operation metadata and bindings in place for primitives.
+- M4.2: Conch validates and dispatches operations via Conduit.
+
+### ERs
+
+- ER-0028 Conduit Operation Model (Verified)
+- ER-0029 Conduit Dispatch Engine (Verified)
+- ER-0030 Conduit Conch Integration (Verified)
+
+### Tests
+
+- Dispatch resolution tests for overloads and inheritance.
+- Conch `call` validation and invocation tests.
+
+---
+
+## Phase 5 — Kernel Runtime Hardening
+
+### Features
+
+- Strengthen CEO task runtime for long-lived kernel execution.
+- Formalize resource and capability hooks (minimal policy, strict plumbing).
+- Define I/O primitives that map to kernel execution contexts.
+
+### Milestones
+
+- M5.1: Task runtime stability under sustained load.
+- M5.2: Capability hooks present for policy enforcement in v2.
+
+### Tests
+
+- Long-run task lifecycle tests.
+- I/O wait/wake stress tests.
+
+---
+
+## Phase 6 — v1 Integration and Kernel Demo
+
+### Features
+
+- End-to-end kernel-grade demo: Conch + Referee + Refract + CEO + Conduit + Structured Types.
+- Document v1 limitations and v2 roadmap.
+
+### Milestones
+
+- M6.1: Kernel demo succeeds with persistent structured data.
+- M6.2: v2 roadmap published and agreed.
+
+---
+
+## ER Placement Summary
+
+### v1 (core kernel and persistence)
+
+- ER-0021, ER-0022, ER-0023, ER-0028, ER-0029, ER-0030, ER-0031, ER-0032, ER-0033
+
+### v2 (utilities and tooling)
+
+- ER-0024, ER-0025, ER-0026, ER-0027
+
+---
+
+## Open Questions
+
+- Exact storage backend choice and migration path from SQLite.
+- Minimum capability/security model required for kernel-grade operation.

--- a/docs/Plan/AR0022plus-Implementation-Plan-v2.md
+++ b/docs/Plan/AR0022plus-Implementation-Plan-v2.md
@@ -1,0 +1,98 @@
+# Implementation Plan: v2 Utilities and Tooling
+
+- Status: Draft
+- Date: 2026-02-27
+- Owners: Mike
+
+## Scope
+
+This plan defines the v2 build, focused on userland utilities and tooling that make the system
+usable for real work. It follows v1 kernel completion and expands parsing, ingestion, and
+developer tools without growing kernel scope.
+
+## Guiding Principles
+
+- Keep the kernel stable; v2 is userland-first.
+- Prefer small, composable tools that operate on IrisOS objects.
+- Favor deterministic, introspectable behaviors over feature breadth.
+
+---
+
+## Phase 1 — Data and Language Parsers
+
+### Features
+
+- JSON and XML parsers for data ingestion and interchange.
+- Constrained C++ and Python parsers for analysis/metadata extraction.
+
+### Milestones
+
+- M1.1: JSON parser usable by Conch or tooling.
+- M1.2: XML parser for legacy inputs.
+- M1.3: C++ and Python subset parsers with documented scope.
+
+### ERs
+
+- ER-0024 JSON Parser (Verified)
+- ER-0025 XML Parser (Verified)
+- ER-0026 C++ Parser (Verified)
+- ER-0027 Python Parser (Verified)
+
+---
+
+## Phase 2 — Core Utilities Suite (GNU-style analogs)
+
+### Features
+
+- Object-aware equivalents of core utilities (list, inspect, filter, transform).
+- Batch import/export tools for Referee objects and Refract schemas.
+- Basic package or bundle mechanism for sharing object graphs and schemas.
+
+### Milestones
+
+- M2.1: Minimal utility suite for object graph operations.
+- M2.2: Import/export workflows for schema and data.
+
+### ERs
+
+- New ERs required.
+
+---
+
+## Phase 3 — Developer Tooling
+
+### Features
+
+- Schema migration tools and validators.
+- Profiling/trace utilities for CEO tasks.
+- Debugging and inspection helpers for Conch and Referee.
+
+### Milestones
+
+- M3.1: Migration tooling baseline.
+- M3.2: Task and object inspection tools.
+
+### ERs
+
+- New ERs required.
+
+---
+
+## Phase 4 — v2 Integration and Usability
+
+### Features
+
+- End-to-end workflows using utilities + parsers + Conch.
+- Document v2 limitations and future roadmap.
+
+### Milestones
+
+- M4.1: v2 usability demo complete.
+- M4.2: v3 roadmap documented.
+
+---
+
+## Open Questions
+
+- Which utilities are required for the first usable userland set?
+- Preferred package/bundle format for object graph distribution.


### PR DESCRIPTION
## Summary\n- add v1 implementation plan focused on persistence + kernel\n- map ER-0021..0033 into v1/v2 placement\n- add v2 plan for utilities and tooling\n\n## Testing\n- not run (docs-only)