### PR TITLE
feat: implement segment-based referee store

### DIFF
--- a/src/referee_sqlite/sqlite_store.h
+++ b/src/referee_sqlite/sqlite_store.h
@@ -2,6 +2,10 @@
 
 #include "referee/referee.h"
 
+#ifdef fail
+#undef fail
+#endif
+
 #include <cstdint>
 #include <fstream>
 #include <optional>


### PR DESCRIPTION
## Summary\n- replace sqlite-backed store implementation with segment/index append-only storage\n- keep existing SqliteStore API while storing data in segment files\n\n## Testing\n- not run (storage changes)