### PR TITLE
docs: add AR ER DR guidelines

### DIFF
--- a/docs/governance/AR-ER-DR-GitHub-Issues.md
+++ b/docs/governance/AR-ER-DR-GitHub-Issues.md
@@ -22,6 +22,10 @@ Status is tracked by labels:
 - `status:in-progress`
 - `status:done`
 
+Issue labels are intentionally coarse-grained. The document keeps the precise status, while the
+issue label groups end states such as `Complete`, `Verified`, `Deferred`, or `Rejected` under
+`status:done`.
+
 ## Workflow
 
 1. Create the Issue using the AR/ER/DR template.

--- a/docs/governance/AR-Guidelines.md
+++ b/docs/governance/AR-Guidelines.md
@@ -1,0 +1,84 @@
+---
+GitHub-Issue: N/A
+---
+
+# AR Guidelines
+
+## Purpose
+
+Architecture Recommendations (ARs) capture durable technical decisions that shape IrisOS structure,
+interfaces, or long-lived constraints. An AR is the record for "we considered options and chose
+this model."
+
+Use an AR when a change:
+
+- affects multiple subsystems or future implementation work
+- introduces a new architectural boundary, invariant, or system model
+- needs explicit alternatives and tradeoff discussion
+- should remain readable after the original implementation context is gone
+
+Do not use an AR for:
+
+- a single bug fix
+- an isolated implementation task
+- progress tracking without an architectural choice
+
+## Document Shape
+
+ARs should stay short and decision-focused. The current AR corpus uses this structure:
+
+- title and metadata
+- context
+- decision or recommendation
+- alternatives considered
+- consequences
+- implementation notes when needed
+
+Write the "why" clearly. The implementation details belong in ERs unless they are necessary to
+explain the decision itself.
+
+## Status and Location
+
+AR status is reflected both in the document and in its directory:
+
+- `Proposed`: draft under `docs/AR/proposed/`
+- `Accepted`: approved record under `docs/AR/accepted/`
+- `Rejected`: keep only if the record is useful for future context
+
+When an AR is accepted, move it from `docs/AR/proposed/` to `docs/AR/accepted/` in the same change
+that updates its status.
+
+If an accepted AR is later replaced, keep the old AR in `accepted/` and note that it has been
+superseded rather than deleting history.
+
+## Relationship to ERs
+
+ARs describe architecture. ERs implement that architecture.
+
+- Prefer landing the AR before or with the first ER that depends on it.
+- If an AR depends on multiple implementation tasks, list them in `ER-Dependencies:`.
+- The sync script can auto-close an AR issue after all listed ERs are `Verified`.
+
+An AR should not become a backlog dump. If the "decision" section turns into a work breakdown, split
+that work into ERs.
+
+## Review Standard
+
+An AR is ready for acceptance when:
+
+- the problem statement is concrete
+- the chosen direction is unambiguous
+- major alternatives are named and rejected for explicit reasons
+- consequences are honest about tradeoffs and constraints
+- downstream ER authors can implement from it without guessing the intended model
+
+## GitHub Tracking
+
+- Use label `ar` for the issue type.
+- Use one status label.
+- GitHub issue status is coarse-grained:
+  - `status:proposed` for proposed ARs
+  - `status:accepted` for accepted ARs
+  - `status:done` for closed-out or rejected records
+
+The AR doc remains the source of truth if the document status is more precise than the issue label.

--- a/docs/governance/DR-Guidelines.md
+++ b/docs/governance/DR-Guidelines.md
@@ -1,0 +1,115 @@
+---
+GitHub-Issue: N/A
+---
+
+# DR Guidelines
+
+## Purpose
+
+Discrepancy Reports (DRs) capture defects, regressions, behavioral mismatches, and other cases
+where the system does not meet expected behavior.
+
+Use a DR when you need a durable record of:
+
+- what is broken
+- how to reproduce it
+- user and system impact
+- severity and priority
+- how the fix will be verified
+
+Do not use a DR for:
+
+- architecture decisions
+- feature requests without an observed discrepancy
+
+## Document Shape
+
+DRs should follow `docs/DR/DR-Template.md`. The most important fields are:
+
+- summary
+- environment
+- steps to reproduce
+- expected behavior
+- actual behavior
+- impact
+- evidence
+- triage notes
+- fix plan
+- verification plan
+
+A DR should make reproduction and validation straightforward for someone who was not present when
+the issue was first reported.
+
+## Severity and Priority
+
+Use severity for technical/user impact and priority for scheduling urgency.
+
+- Severity:
+  - `Critical`: data loss, corruption, or core system unusable
+  - `High`: major feature broken or strong workflow regression
+  - `Medium`: clear defect with viable workaround
+  - `Low`: limited impact or cosmetic/ergonomic issue
+- Priority:
+  - `P0`: immediate attention
+  - `P1`: next practical fix window
+  - `P2`: important but not urgent
+  - `P3`: backlog candidate
+
+Do not use priority as a substitute for severity; record both.
+
+## Status Lifecycle
+
+DR documents may use:
+
+- `New`
+- `Triaged`
+- `Proposed`
+- `In Progress`
+- `Fixed`
+- `Complete`
+- `Verified`
+- `Deferred`
+- `Rejected`
+
+Recommended usage:
+
+- `New`: reported, not yet assessed
+- `Triaged`: reproduced or analyzed enough to scope impact
+- `Proposed`: fix direction chosen
+- `In Progress`: fix underway
+- `Fixed` / `Complete`: change landed, awaiting verification
+- `Verified`: system engineer has confirmed the fix
+- `Deferred`: real issue, intentionally postponed
+- `Rejected`: not a bug or not accepted for action
+
+Only the System Engineer marks a DR as `Verified`.
+
+## Relationship to ERs
+
+Use a DR as the problem record and an ER as the implementation plan when the fix is substantial.
+
+- Small, direct fixes may be handled directly from the DR.
+- Larger fixes should reference an ER in the DR triage or fix plan.
+- Keep the DR focused on the discrepancy even if the implementation spans multiple commits.
+
+## GitHub Tracking
+
+- Use label `dr` for the issue type.
+- Use one coarse-grained status label on the issue.
+
+Issue label mapping is broader than document status:
+
+- `status:proposed` maps to `New`, `Triaged`, and `Proposed`
+- `status:in-progress` maps to `In Progress`
+- `status:done` maps to `Fixed`, `Complete`, `Verified`, `Deferred`, and `Rejected`
+
+The DR document is the authoritative status record when more precision is needed.
+
+## Review Standard
+
+A DR is ready for implementation when:
+
+- reproduction is concrete or the failure evidence is strong
+- impact is explicit
+- the suspected cause is narrow enough to act on
+- verification steps prove the issue is fixed rather than merely hidden

--- a/docs/governance/ER-Guidelines.md
+++ b/docs/governance/ER-Guidelines.md
@@ -1,0 +1,107 @@
+---
+GitHub-Issue: N/A
+---
+
+# ER Guidelines
+
+## Purpose
+
+Engineering Requests (ERs) define implementation-scoped work. They are the planning and acceptance
+record for new functionality, integration milestones, or grouped delivery work such as epics and
+sprints.
+
+Use an ER when work needs:
+
+- clear scope and non-goals
+- acceptance criteria
+- implementation and verification notes
+- a durable record of what "done" means
+
+Do not use an ER for:
+
+- architecture-only decisions with no immediate implementation scope
+- one-off bug triage where the primary artifact should be a DR
+
+## Document Shape
+
+ERs should follow `docs/ER/ER-Template.md`. In practice, the important sections are:
+
+- metadata
+- context
+- goals and non-goals
+- scope
+- requirements
+- proposed approach
+- acceptance criteria
+- dependencies
+- implementation notes
+- verification plan
+
+If an ER grows into a roadmap or umbrella item, keep the parent ER short and split concrete work
+into sub-ERs.
+
+## Status Lifecycle
+
+ER documents may use:
+
+- `Draft`
+- `Proposed`
+- `Approved`
+- `In Progress`
+- `Implemented`
+- `Complete`
+- `Verified`
+- `Rejected`
+
+Recommended usage:
+
+- `Draft` / `Proposed`: the work is being shaped
+- `Approved`: direction accepted, implementation not yet started
+- `In Progress`: implementation underway
+- `Implemented` / `Complete`: implementation landed, verification still pending
+- `Verified`: system engineer has confirmed the result
+
+Only the System Engineer marks an ER as `Verified`.
+
+## ER Ledger and Verification
+
+- Keep the ER document status current.
+- Update `docs/ER/ER-Status.md` when ER status changes.
+- When implementing an ER, update its status in the same commit as the implementation.
+- Do not mark an ER `Verified` from an implementation-only pass.
+
+## Relationship to ARs and DRs
+
+- An ER may implement one or more AR decisions.
+- An ER may also be the planned fix vehicle for a DR.
+- If a DR exposes a defect but the fix requires substantial scoped work, the DR can point to the
+  implementing ER.
+
+ERs should stay implementation-oriented. If the core question is "what architecture should we use,"
+write an AR first.
+
+## GitHub Tracking
+
+- Use label `er` for the issue type.
+- Use one coarse-grained status label on the issue.
+
+Issue label mapping is intentionally broader than document status:
+
+- `status:proposed` maps to `Draft` and `Proposed`
+- `status:accepted` maps to `Approved`
+- `status:in-progress` maps to `In Progress`
+- `status:done` maps to `Implemented`, `Complete`, `Verified`, and `Rejected`
+
+The ER document is the source of truth for the precise status.
+
+## Review Standard
+
+An ER is ready for implementation when:
+
+- scope is small enough to review coherently
+- dependencies are explicit
+- acceptance criteria are testable
+- verification steps are concrete
+- out-of-scope items are clearly excluded
+
+An ER is ready for `Complete` when implementation and intended validation are in place.

--- a/docs/governance/GitHub-Issue-Labels.md
+++ b/docs/governance/GitHub-Issue-Labels.md
@@ -36,4 +36,6 @@ purpose-built for IrisOS.
 
 - Every issue should have one **type** label.
 - Use **status** labels for AR/ER/DR issues.
+- Treat `status:done` as the closed-state label for document statuses such as `Complete`,
+  `Verified`, `Deferred`, or `Rejected`.
 - Add **area** labels only when they help triage.


### PR DESCRIPTION
## Summary
- populate the previously empty AR guidelines document
- add dedicated ER and DR guideline docs aligned with the existing templates and issue sync workflow
- clarify that GitHub  is a coarse-grained closed-state label while the document carries the precise status

## Validation
- reviewed existing governance docs, templates, and scripts/issue_sync.sh for status mapping consistency

## Notes
- this PR is docs-only and does not change code or generated files