### PR TITLE
fix: align AR status and typed result errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,16 @@ Your job: make safe, reviewable, minimal diffs that pass CI and match existing a
 ---
 
 ## Non-Negotiables
+- **Don't assume.  If there is something that has multiple solutions, ask.
+- **Don't hide confusion.  Say "I don't know" often.
+- **Surface tradeoffs.  You may not make decisions by yourself.
 - **Do not change behavior unrelated to the request.**
 - **Prefer the smallest correct diff.**
+- **Do not speculate solutions.  ask**
 - **No drive-by refactors** (formatting, renaming, reorganizing, “cleanups”) unless explicitly asked.
 - **No destructive actions** (deleting files, force pushes, history edits, massive rewrites) without explicit instruction.
 - **Do not add new dependencies** unless explicitly requested or truly unavoidable (and justified).
+- **Continuously redefine success criteria until approved.
 
 ### File Size & Formatting
 - Do not compact or reflow lines in ways that risk obscuring or losing content.

--- a/docs/AR/accepted/AR-0005-Service-Plane-Model.md
+++ b/docs/AR/accepted/AR-0005-Service-Plane-Model.md
@@ -5,7 +5,7 @@ ER-Dependencies: ER-0001, ER-0044, ER-0057
 
 # AR-0005 — Service Plane Model (Recommendation)
 
-- Status: Accepted
+- Status: Implemented
 - Date: 2026-02-16
 - Owners: Mike
 

--- a/docs/AR/accepted/AR-0007-Refract-Reflection-Graph.md
+++ b/docs/AR/accepted/AR-0007-Refract-Reflection-Graph.md
@@ -5,7 +5,7 @@ ER-Dependencies: ER-0002, ER-0004, ER-0037, ER-0055, ER-0078, ER-0079, ER-0080
 
 # AR-0007 — Refract Reflection Graph (Recommendation)
 
-- Status: Accepted
+- Status: Implemented
 - Date: 2026-02-16
 - Owners: Mike
 

--- a/docs/AR/accepted/AR-0008-Erector-Subsystems.md
+++ b/docs/AR/accepted/AR-0008-Erector-Subsystems.md
@@ -5,7 +5,7 @@ ER-Dependencies: ER-0015, ER-0016, ER-0017, ER-0032, ER-0033, ER-0045, ER-0045.1
 
 # AR-0008 — Erector Subsystems (Recommendation)
 
-- Status: Accepted
+- Status: Implemented
 - Date: 2026-02-16
 - Owners: Mike
 

--- a/docs/AR/accepted/AR-0010-Comms-Subsystem.md
+++ b/docs/AR/accepted/AR-0010-Comms-Subsystem.md
@@ -5,7 +5,7 @@ ER-Dependencies: ER-0015, ER-0016, ER-0017, ER-0045, ER-0045.1, ER-0045.2, ER-00
 
 # AR-0010 — Comms Subsystem (Recommendation)
 
-- Status: Accepted
+- Status: Implemented
 - Date: 2026-02-16
 - Owners: Mike
 

--- a/docs/governance/Architecture-Decision-Index.json
+++ b/docs/governance/Architecture-Decision-Index.json
@@ -45,7 +45,7 @@
       "Public subsystem APIs should return a project Result type rather than using exceptions for normal control flow.",
       "Exceptions must not cross subsystem boundaries as the normal error mechanism.",
       "NotFound semantics must be explicit and consistent at the API boundary.",
-      "The accepted AR-0001 target is typed expected-style errors with ErrorCode. Current implementation uses string-based referee::Result, so this remains a known conformance gap until resolved or AR-0001 is amended."
+      "The accepted AR-0001 target is typed expected-style errors with ErrorCode. Current implementation exposes typed ErrorCode through the existing referee::Result compatibility wrapper; migration to std::expected remains future work unless AR-0001 is amended."
     ],
     "persistence": [
       "Persisted data must be deterministic across process restarts.",
@@ -73,8 +73,8 @@
       "conformance": "Partial",
       "notes": [
         "The AR specifies std::expected<T, ErrorCode> and enum class ErrorCode.",
-        "The current implementation uses referee::Result<T> with string Error messages.",
-        "A follow-up ER or AR amendment is needed before this can be treated as implemented."
+        "The current implementation provides enum class ErrorCode through the existing referee::Result<T> wrapper for source compatibility.",
+        "A follow-up ER or AR amendment is needed before the exact std::expected alias can be treated as implemented."
       ]
     },
     {
@@ -98,9 +98,9 @@
     {
       "id": "AR-0005",
       "name": "Service Plane Model",
-      "status": "Accepted",
+      "status": "Implemented",
       "decision": "Model long-running services as stable service objects with lifecycle, discovery, messaging, and isolation.",
-      "conformance": "Partial",
+      "conformance": "Implemented with future stages",
       "notes": [
         "Later staged delivery is defined by AR-0022.",
         "Persistent capability context, service boundary enforcement, isolation hooks, and expanded service classes remain planned work."
@@ -115,9 +115,9 @@
     {
       "id": "AR-0007",
       "name": "Refract Reflection Graph",
-      "status": "Accepted",
+      "status": "Implemented",
       "decision": "Make Refract the persistent reflection graph for types, fields, operations, relationships, constraints, effects, and documentation.",
-      "conformance": "Partial",
+      "conformance": "Implemented with future stages",
       "notes": [
         "AR-0023 defines profile boundaries.",
         "ER-0078, ER-0079, and ER-0080 close remaining extended reflection scope."
@@ -126,9 +126,9 @@
     {
       "id": "AR-0008",
       "name": "Erector Subsystems",
-      "status": "Accepted",
+      "status": "Implemented",
       "decision": "Use Erector as the foundation for Math, Refract, Machine, Exec, and Comms object types.",
-      "conformance": "Partial",
+      "conformance": "Implemented with future stages",
       "notes": [
         "Exec, Comms primitives, Astra, and Caliper exist.",
         "Erector::Machine remains a planned subsystem under AR-0024."
@@ -143,9 +143,9 @@
     {
       "id": "AR-0010",
       "name": "Comms Subsystem",
-      "status": "Accepted",
+      "status": "Implemented",
       "decision": "Model communication through object-oriented link, transport, session, protocol, and addressing abstractions.",
-      "conformance": "Partial",
+      "conformance": "Implemented with future stages",
       "notes": [
         "Current implementation covers in-memory primitives and CEO I/O integration.",
         "Machine-backed transport, session, and protocol objects remain planned work under AR-0024."
@@ -299,8 +299,8 @@
     {
       "area": "Error model",
       "source": "AR-0001",
-      "gap": "No enum class ErrorCode exists, and Result is string-based rather than std::expected<T, ErrorCode>.",
-      "recommended_resolution": "Draft an ER to implement typed errors or amend AR-0001 to match the accepted project Result model."
+      "gap": "Result now carries ErrorCode, but the project still uses its compatibility wrapper rather than std::expected<T, ErrorCode>.",
+      "recommended_resolution": "Draft a follow-up ER for std::expected migration or amend AR-0001 to accept the existing project Result wrapper."
     },
     {
       "area": "Service Plane",

--- a/src/referee/referee.h
+++ b/src/referee/referee.h
@@ -5,6 +5,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace referee {
@@ -72,7 +73,22 @@ struct EdgeRecord {
 // -----------------------------
 // Errors
 // -----------------------------
+enum class ErrorCode {
+  Unknown,
+  InvalidArgument,
+  NotFound,
+  AlreadyExists,
+  FailedPrecondition,
+  IoError,
+  ParseError,
+  Timeout,
+  CorruptData,
+  Unsupported,
+  Internal,
+};
+
 struct Error {
+  ErrorCode code{ErrorCode::Unknown};
   std::string message;
 };
 
@@ -84,7 +100,13 @@ struct Result {
   std::optional<Error> error;
 
   static Result ok(T v) { return Result{std::optional<T>(std::move(v)), std::nullopt}; }
-  static Result err(std::string msg) { return Result{std::nullopt, Error{std::move(msg)}}; }
+  static Result err(std::string msg) {
+    return Result{std::nullopt, Error{ErrorCode::Unknown, std::move(msg)}};
+  }
+  static Result err(ErrorCode code, std::string msg) {
+    return Result{std::nullopt, Error{code, std::move(msg)}};
+  }
+  static Result err(Error error) { return Result{std::nullopt, std::move(error)}; }
 
   explicit operator bool() const { return value.has_value() && !error.has_value(); }
 };
@@ -96,7 +118,13 @@ struct Result<void> {
   std::optional<Error> error;
 
   static Result ok() { return Result{true, std::nullopt}; }
-  static Result err(std::string msg) { return Result{false, Error{std::move(msg)}}; }
+  static Result err(std::string msg) {
+    return Result{false, Error{ErrorCode::Unknown, std::move(msg)}};
+  }
+  static Result err(ErrorCode code, std::string msg) {
+    return Result{false, Error{code, std::move(msg)}};
+  }
+  static Result err(Error error) { return Result{false, std::move(error)}; }
 
   explicit operator bool() const { return ok_ && !error.has_value(); }
 };

--- a/tests/test_referee_core.cc
+++ b/tests/test_referee_core.cc
@@ -99,12 +99,29 @@ START_TEST(test_edges_from_and_to)
 }
 END_TEST
 
+START_TEST(test_result_carries_typed_error_code)
+{
+  auto invalid = Result<int>::err(ErrorCode::InvalidArgument, "bad input");
+  ck_assert_msg(!invalid, "expected typed error result");
+  ck_assert_msg(invalid.error.has_value(), "expected error payload");
+  ck_assert(invalid.error->code == ErrorCode::InvalidArgument);
+  ck_assert_str_eq(invalid.error->message.c_str(), "bad input");
+
+  auto legacy = Result<void>::err("legacy error");
+  ck_assert_msg(!legacy, "expected legacy error result");
+  ck_assert_msg(legacy.error.has_value(), "expected legacy error payload");
+  ck_assert(legacy.error->code == ErrorCode::Unknown);
+  ck_assert_str_eq(legacy.error->message.c_str(), "legacy error");
+}
+END_TEST
+
 Suite* referee_suite(void) {
   Suite* s = suite_create("RefereeCore");
   TCase* tc = tcase_create("core");
 
   tcase_add_test(tc, test_create_and_get_object_roundtrip);
   tcase_add_test(tc, test_edges_from_and_to);
+  tcase_add_test(tc, test_result_carries_typed_error_code);
 
   suite_add_tcase(s, tc);
   return s;


### PR DESCRIPTION
## Summary
- mark AR-0005, AR-0007, AR-0008, and AR-0010 as Implemented while preserving future-stage notes in the architecture index
- add typed ErrorCode support to the existing referee::Result compatibility wrapper
- add focused coverage for typed and legacy Result errors

## Validation
- make -j
- make check

## Notes
- No Autotools source-of-truth files were changed and generated-file churn was excluded.
- AR-0001 remains partial for exact std::expected alias migration; the compatibility gap is narrowed to the remaining std::expected question.