### PR TITLE
docs: accept result wrapper for AR-0001

### DIFF
--- a/docs/AR/accepted/AR-0001-Error-Model.md
+++ b/docs/AR/accepted/AR-0001-Error-Model.md
@@ -31,11 +31,11 @@ We must decide:
 
 ## Decision
 
-Referee adopts an expected-style return model:
+Referee adopts a project result return model with expected-style semantics:
 
 1. Public APIs return:
 
-   `std::expected<T, ErrorCode>`
+   `Result<T>`
 
 2. Exceptions are NOT used for normal control flow.
 
@@ -49,7 +49,12 @@ Referee adopts an expected-style return model:
 6. A project alias will be defined:
 
    `template<typename T>`
-   `using Result = std::expected<T, ErrorCode>;`
+   `using Result = ...;`
+
+   The concrete backing type is an irisOS implementation detail. It may be
+   `std::expected<T, ErrorCode>` where the project toolchain supports it, or a
+   project-owned compatibility wrapper with the same success/error boundary
+   semantics.
 
 ## Alternatives Considered
 
@@ -85,6 +90,7 @@ Negative:
 
 - More verbose call sites
 - Slight increase in template surface
+- Project code must preserve `Result<T>` semantics if the backing type changes
 
 ## Implementation Notes
 
@@ -93,4 +99,3 @@ Negative:
 - Provide helper functions for ergonomic chaining
 - Update storage layer first
 - Tests assert on specific error codes
-

--- a/docs/governance/Architecture-Decision-Index.json
+++ b/docs/governance/Architecture-Decision-Index.json
@@ -45,7 +45,7 @@
       "Public subsystem APIs should return a project Result type rather than using exceptions for normal control flow.",
       "Exceptions must not cross subsystem boundaries as the normal error mechanism.",
       "NotFound semantics must be explicit and consistent at the API boundary.",
-      "The accepted AR-0001 target is typed expected-style errors with ErrorCode. Current implementation exposes typed ErrorCode through the existing referee::Result compatibility wrapper; migration to std::expected remains future work unless AR-0001 is amended."
+      "The accepted AR-0001 target is typed expected-style errors with ErrorCode exposed through the project Result abstraction."
     ],
     "persistence": [
       "Persisted data must be deterministic across process restarts.",
@@ -72,9 +72,9 @@
       "decision": "Use explicit result-style error propagation and avoid exceptions as normal cross-boundary control flow.",
       "conformance": "Partial",
       "notes": [
-        "The AR specifies std::expected<T, ErrorCode> and enum class ErrorCode.",
-        "The current implementation provides enum class ErrorCode through the existing referee::Result<T> wrapper for source compatibility.",
-        "A follow-up ER or AR amendment is needed before the exact std::expected alias can be treated as implemented."
+        "The AR specifies Result<T> with expected-style semantics and enum class ErrorCode.",
+        "The current implementation provides enum class ErrorCode through referee::Result<T>.",
+        "Remaining conformance depends on settling lookup absence semantics consistently with the AR."
       ]
     },
     {
@@ -299,8 +299,8 @@
     {
       "area": "Error model",
       "source": "AR-0001",
-      "gap": "Result now carries ErrorCode, but the project still uses its compatibility wrapper rather than std::expected<T, ErrorCode>.",
-      "recommended_resolution": "Draft a follow-up ER for std::expected migration or amend AR-0001 to accept the existing project Result wrapper."
+      "gap": "Lookup absence semantics still need to be settled consistently with the AR's NotFound guidance.",
+      "recommended_resolution": "Amend AR-0001 to accept intentional Result<std::optional<T>> probe APIs, or create an ER to migrate lookup absence to ErrorCode::NotFound."
     },
     {
       "area": "Service Plane",


### PR DESCRIPTION
## Summary
- Amend AR-0001 so public APIs target the irisOS Result<T> abstraction instead of requiring direct std::expected exposure.
- Update the architecture index to remove std::expected migration as the AR-0001 gap.
- Keep AR-0001 at Accepted/Partial and record lookup absence semantics as the remaining conformance question.

## Validation
- python3 -m json.tool docs/governance/Architecture-Decision-Index.json
- git diff --check -- docs/AR/accepted/AR-0001-Error-Model.md docs/governance/Architecture-Decision-Index.json