### PR TITLE
feat: add ER-0058 capability contexts

### DIFF
--- a/docs/ER/ER-0058-Capability-Context-Objects-and-Persistence.md
+++ b/docs/ER/ER-0058-Capability-Context-Objects-and-Persistence.md
@@ -1,0 +1,91 @@
+---
+GitHub-Issue: N/A
+---
+
+# ER-0058 — Capability Context Objects and Persistence
+
+## Roles
+
+- Implementation Engineer: drafts and implements changes
+- System Engineer: reviews, tests, and verifies
+- Note: Only the System Engineer may mark an ER as Verified.
+
+## ER Metadata
+
+- ER ID: ER-0058
+- Title: Capability Context Objects and Persistence
+- Status: Complete
+- Date: 2026-05-26
+- Owners: Mike
+- Type: Enhancement
+
+## Engineering Guidelines
+
+- Implementation language baseline: C++20 or C++24.
+- Avoid line compaction or formatting changes that risk obscuring or losing content.
+- Keep source files reasonably small. If a file grows too large to be fully replaced in a change, split it into smaller local files.
+
+## Context
+
+- Problem statement: Service Plane Stage D requires capability-aware service context, but the current service substrate has no persisted capability context object that can be attached to service, task, or object identity.
+- Background / constraints: AR-0005 defines explicit capabilities and access policies as part of service isolation. AR-0022 stages this work after persistent service lifecycle and registry behavior.
+
+## Goals
+
+- Introduce a first-class capability context model.
+- Persist capability context records in Referee.
+- Support deterministic reload and lookup by context ID and attached subject ID.
+
+## Non-Goals
+
+- Full policy enforcement.
+- Service-boundary authorization checks.
+- Sandbox isolation semantics.
+- Conch command surfaces for capability administration.
+
+## Scope
+
+- In scope: capability context identity, subject attachment, optional sandbox attachment, and explicit grant names.
+- In scope: Referee persistence and reload helpers.
+- In scope: tests for round-trip persistence, subject lookup, and invalid grant rejection.
+- Out of scope: policy engine, capability service implementation, and runtime enforcement at service boundaries.
+
+## Requirements
+
+- Functional: capability contexts can be persisted and reloaded through Referee.
+- Functional: capability contexts can be listed by attached subject object ID.
+- Functional: empty or duplicate capability grant names are rejected deterministically.
+- Non-functional: persisted grant ordering is deterministic.
+
+## Proposed Approach
+
+- Summary: add a small `CapabilityContext` data model and `CapabilityContextStore` persistence helper under the service subsystem, encoded as Referee object payloads.
+- Alternatives considered: folding context fields directly into service descriptors was rejected because task, service, and future sandbox subjects need a reusable context object.
+
+## Acceptance Criteria
+
+- Tests verify capability context persistence survives store reopen.
+- Tests verify lookup by subject returns the attached contexts.
+- Tests verify empty and duplicate grant names are rejected.
+
+## Risks / Open Questions
+
+- Risk: this creates the data layer before policy enforcement, so callers may assume grants are enforced earlier than they are.
+- Question: which grant taxonomy should become canonical before ER-0060 service-boundary checks?
+
+## Dependencies
+
+- Dependency 1: AR-0005 Service Plane Model.
+- Dependency 2: AR-0022 Staged Service Plane Delivery.
+- Dependency 3: ER-0057 Service Host Lifecycle and Persistent Registry.
+
+## Implementation Notes
+
+- Notes for implementer: keep this ER limited to persisted context data and lookup behavior. Service-boundary enforcement belongs to a follow-on ER.
+
+## Verification Plan
+
+- Tests to run:
+  - `make check`
+- Manual checks:
+  - inspect persisted capability context records by context ID and subject ID.

--- a/docs/ER/ER-Status.md
+++ b/docs/ER/ER-Status.md
@@ -67,6 +67,7 @@
 - ER-0055 — Verified
 - ER-0056 — Verified
 - ER-0057 — Verified
+- ER-0058 — Complete
 - ER-0078 — Complete
 - ER-0079 — Proposed
 - ER-0080 — Proposed

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -33,6 +33,8 @@ libreferee_la_SOURCES = \
    vizier/routing.cc \
    viz/artifacts.h \
    viz/artifacts.cc \
+   services/capability_context.h \
+   services/capability_context.cc \
    services/service.h \
    services/service.cc \
    refract/bootstrap.h \
@@ -68,4 +70,5 @@ include_HEADERS = referee/referee.h \
    parser/xml_parser.h \
    comms/primitives.h \
    vizier/routing.h \
-   viz/artifacts.h
+   viz/artifacts.h \
+   services/capability_context.h

--- a/src/services/capability_context.cc
+++ b/src/services/capability_context.cc
@@ -1,0 +1,176 @@
+#include "services/capability_context.h"
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <exception>
+#include <unordered_set>
+
+namespace iris::service {
+
+namespace {
+
+referee::Result<CapabilityContext> validate_context(CapabilityContext context) {
+  std::unordered_set<std::string> seen;
+  for (const auto& grant : context.grants) {
+    if (grant.name.empty()) {
+      return referee::Result<CapabilityContext>::err(
+          referee::ErrorCode::InvalidArgument,
+          "capability grant name is empty");
+    }
+    if (!seen.insert(grant.name).second) {
+      return referee::Result<CapabilityContext>::err(
+          referee::ErrorCode::InvalidArgument,
+          "duplicate capability grant: " + grant.name);
+    }
+  }
+
+  std::sort(context.grants.begin(), context.grants.end(),
+            [](const CapabilityGrant& lhs, const CapabilityGrant& rhs) {
+              return lhs.name < rhs.name;
+            });
+  return referee::Result<CapabilityContext>::ok(std::move(context));
+}
+
+nlohmann::json context_to_json(const CapabilityContext& context) {
+  nlohmann::json j;
+  j["subject"] = context.subject.to_hex();
+  if (context.sandbox.has_value()) j["sandbox"] = context.sandbox->to_hex();
+  j["grants"] = nlohmann::json::array();
+  for (const auto& grant : context.grants) {
+    j["grants"].push_back(grant.name);
+  }
+  return j;
+}
+
+referee::Result<CapabilityContext> context_from_json(referee::ObjectID id,
+                                                     const nlohmann::json& j) {
+  if (!j.is_object()) {
+    return referee::Result<CapabilityContext>::err(
+        referee::ErrorCode::CorruptData,
+        "capability context payload must be an object");
+  }
+  if (!j.contains("subject")) {
+    return referee::Result<CapabilityContext>::err(
+        referee::ErrorCode::CorruptData,
+        "capability context missing subject");
+  }
+  if (!j.contains("grants") || !j.at("grants").is_array()) {
+    return referee::Result<CapabilityContext>::err(
+        referee::ErrorCode::CorruptData,
+        "capability context grants must be an array");
+  }
+
+  CapabilityContext context;
+  context.id = id;
+  try {
+    context.subject = referee::ObjectID::from_hex(j.at("subject").get<std::string>());
+    if (j.contains("sandbox")) {
+      context.sandbox = referee::ObjectID::from_hex(j.at("sandbox").get<std::string>());
+    }
+    for (const auto& item : j.at("grants")) {
+      context.grants.push_back(CapabilityGrant{item.get<std::string>()});
+    }
+  } catch (const std::exception& ex) {
+    return referee::Result<CapabilityContext>::err(referee::ErrorCode::CorruptData, ex.what());
+  }
+
+  return validate_context(std::move(context));
+}
+
+referee::Result<CapabilityContextRecord> record_from_object(const referee::ObjectRecord& rec) {
+  try {
+    auto json = nlohmann::json::from_cbor(rec.payload_cbor);
+    auto contextR = context_from_json(rec.ref.id, json);
+    if (!contextR) {
+      return referee::Result<CapabilityContextRecord>::err(contextR.error.value());
+    }
+    CapabilityContextRecord out;
+    out.ref = rec.ref;
+    out.context = std::move(contextR.value.value());
+    return referee::Result<CapabilityContextRecord>::ok(std::move(out));
+  } catch (const std::exception& ex) {
+    return referee::Result<CapabilityContextRecord>::err(referee::ErrorCode::CorruptData,
+                                                         ex.what());
+  }
+}
+
+} // namespace
+
+CapabilityContextStore::CapabilityContextStore(referee::SqliteStore& store) : store_(store) {}
+
+referee::Result<CapabilityContextRecord> CapabilityContextStore::persist_context(
+    const CapabilityContext& context) {
+  auto normalizedR = validate_context(context);
+  if (!normalizedR) {
+    return referee::Result<CapabilityContextRecord>::err(normalizedR.error.value());
+  }
+
+  const auto& normalized = normalizedR.value.value();
+  auto payload = nlohmann::json::to_cbor(context_to_json(normalized));
+  auto recR = store_.create_object_with_id(normalized.id,
+                                           kCapabilityContextType,
+                                           referee::ObjectID{},
+                                           payload);
+  if (!recR) return referee::Result<CapabilityContextRecord>::err(recR.error.value());
+
+  CapabilityContextRecord out;
+  out.ref = recR.value->ref;
+  out.context = normalized;
+  return referee::Result<CapabilityContextRecord>::ok(std::move(out));
+}
+
+referee::Result<std::optional<CapabilityContextRecord>> CapabilityContextStore::get_context(
+    referee::ObjectID id) {
+  auto recR = store_.get_latest(id);
+  if (!recR) return referee::Result<std::optional<CapabilityContextRecord>>::err(recR.error.value());
+  if (!recR.value->has_value()) {
+    return referee::Result<std::optional<CapabilityContextRecord>>::ok(std::nullopt);
+  }
+  if (recR.value->value().type != kCapabilityContextType) {
+    return referee::Result<std::optional<CapabilityContextRecord>>::err(
+        referee::ErrorCode::InvalidArgument,
+        "object is not a capability context");
+  }
+
+  auto recordR = record_from_object(recR.value->value());
+  if (!recordR) {
+    return referee::Result<std::optional<CapabilityContextRecord>>::err(recordR.error.value());
+  }
+  return referee::Result<std::optional<CapabilityContextRecord>>::ok(recordR.value.value());
+}
+
+referee::Result<std::vector<CapabilityContextRecord>> CapabilityContextStore::list_contexts() {
+  auto recordsR = store_.list_by_type(kCapabilityContextType);
+  if (!recordsR) return referee::Result<std::vector<CapabilityContextRecord>>::err(recordsR.error.value());
+
+  std::vector<CapabilityContextRecord> out;
+  out.reserve(recordsR.value->size());
+  for (const auto& rec : recordsR.value.value()) {
+    auto contextR = record_from_object(rec);
+    if (!contextR) {
+      return referee::Result<std::vector<CapabilityContextRecord>>::err(contextR.error.value());
+    }
+    out.push_back(std::move(contextR.value.value()));
+  }
+
+  std::sort(out.begin(), out.end(), [](const CapabilityContextRecord& lhs,
+                                       const CapabilityContextRecord& rhs) {
+    return lhs.context.id.to_hex() < rhs.context.id.to_hex();
+  });
+  return referee::Result<std::vector<CapabilityContextRecord>>::ok(std::move(out));
+}
+
+referee::Result<std::vector<CapabilityContextRecord>>
+CapabilityContextStore::list_contexts_for_subject(referee::ObjectID subject) {
+  auto contextsR = list_contexts();
+  if (!contextsR) return contextsR;
+
+  std::vector<CapabilityContextRecord> out;
+  for (auto& record : contextsR.value.value()) {
+    if (record.context.subject == subject) out.push_back(std::move(record));
+  }
+  return referee::Result<std::vector<CapabilityContextRecord>>::ok(std::move(out));
+}
+
+} // namespace iris::service

--- a/src/services/capability_context.h
+++ b/src/services/capability_context.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "referee/referee.h"
+#include "referee_sqlite/sqlite_store.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace iris::service {
+
+struct CapabilityGrant {
+  std::string name;
+};
+
+struct CapabilityContext {
+  referee::ObjectID id{};
+  referee::ObjectID subject{};
+  std::optional<referee::ObjectID> sandbox;
+  std::vector<CapabilityGrant> grants{};
+};
+
+struct CapabilityContextRecord {
+  referee::ObjectRef ref{};
+  CapabilityContext context{};
+};
+
+constexpr referee::TypeID kCapabilityContextType{0x5356434341500001ULL};
+
+class CapabilityContextStore {
+public:
+  explicit CapabilityContextStore(referee::SqliteStore& store);
+
+  referee::Result<CapabilityContextRecord> persist_context(const CapabilityContext& context);
+  referee::Result<std::optional<CapabilityContextRecord>> get_context(referee::ObjectID id);
+  referee::Result<std::vector<CapabilityContextRecord>> list_contexts();
+  referee::Result<std::vector<CapabilityContextRecord>> list_contexts_for_subject(
+      referee::ObjectID subject);
+
+private:
+  referee::SqliteStore& store_;
+};
+
+} // namespace iris::service

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,7 +4,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/src $(CHECK_CFLAGS) \
 	-DIRIS_TOP_BUILDDIR=\"$(abs_top_builddir)\"
 AM_TESTS_ENVIRONMENT = CK_FORK=no
 
-TESTS = test_referee_core test_service_ipc test_refract_registry test_refract_bootstrap test_ceo_tasks test_exec_waitables test_exec_integration test_vizier_routing test_viz_artifacts test_phase3_integration test_comms_primitives test_ceo_io_reactor test_phase5_integration test_phase6_persistence test_conch_authoring test_parser_core test_conch_parser test_json_parser test_cpp_parser test_python_parser test_xml_parser
+TESTS = test_referee_core test_service_ipc test_capability_context test_refract_registry test_refract_bootstrap test_ceo_tasks test_exec_waitables test_exec_integration test_vizier_routing test_viz_artifacts test_phase3_integration test_comms_primitives test_ceo_io_reactor test_phase5_integration test_phase6_persistence test_conch_authoring test_parser_core test_conch_parser test_json_parser test_cpp_parser test_python_parser test_xml_parser
 check_PROGRAMS = $(TESTS)
 
 test_referee_core_SOURCES = test_referee_core.cc
@@ -12,6 +12,9 @@ test_referee_core_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la
 
 test_service_ipc_SOURCES = test_service_ipc.cc
 test_service_ipc_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la
+
+test_capability_context_SOURCES = test_capability_context.cc
+test_capability_context_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la
 
 test_refract_registry_SOURCES = test_refract_registry.cc
 test_refract_registry_LDADD = $(CHECK_LIBS) $(top_builddir)/src/libreferee.la

--- a/tests/test_capability_context.cc
+++ b/tests/test_capability_context.cc
@@ -1,0 +1,155 @@
+extern "C" {
+#include <check.h>
+}
+#ifdef fail
+#undef fail
+#endif
+
+#include "services/capability_context.h"
+
+#include <cstdio>
+#include <string>
+#include <unistd.h>
+
+using namespace iris::service;
+using namespace referee;
+
+namespace {
+
+template <typename T>
+const char* result_message(const Result<T>& r) {
+  return r.error.has_value() ? r.error->message.c_str() : "ok";
+}
+
+std::string make_temp_db_path() {
+  char tmpl[] = "/tmp/iris_capability_XXXXXX";
+  int fd = mkstemp(tmpl);
+  if (fd >= 0) close(fd);
+  std::string path(tmpl);
+  std::remove(path.c_str());
+  return path;
+}
+
+void cleanup_db_files(const std::string& path) {
+  std::remove(path.c_str());
+  std::string shm = path + "-shm";
+  std::string wal = path + "-wal";
+  std::remove(shm.c_str());
+  std::remove(wal.c_str());
+}
+
+} // namespace
+
+START_TEST(test_capability_context_roundtrip_and_subject_lookup)
+{
+  std::string db_path = make_temp_db_path();
+  ObjectID context_id = ObjectID::random();
+  ObjectID subject_id = ObjectID::random();
+  ObjectID sandbox_id = ObjectID::random();
+
+  {
+    SqliteStore store(SqliteConfig{ .filename=db_path, .enable_wal=true });
+    ck_assert_msg(store.open(), "open failed");
+    ck_assert_msg(store.ensure_schema(), "ensure_schema failed");
+
+    CapabilityContext context;
+    context.id = context_id;
+    context.subject = subject_id;
+    context.sandbox = sandbox_id;
+    context.grants.push_back(CapabilityGrant{"service.registry.read"});
+    context.grants.push_back(CapabilityGrant{"service.lifecycle.start"});
+
+    CapabilityContextStore contexts(store);
+    auto savedR = contexts.persist_context(context);
+    ck_assert_msg(savedR, "persist_context failed: %s", result_message(savedR));
+    ck_assert(savedR.value->context.id == context_id);
+    ck_assert(savedR.value->context.subject == subject_id);
+    ck_assert(savedR.value->context.sandbox.has_value());
+    ck_assert(savedR.value->context.sandbox.value() == sandbox_id);
+
+    ck_assert_msg(store.close(), "close failed");
+  }
+
+  {
+    SqliteStore store(SqliteConfig{ .filename=db_path, .enable_wal=true });
+    ck_assert_msg(store.open(), "open failed");
+    ck_assert_msg(store.ensure_schema(), "ensure_schema failed");
+
+    CapabilityContextStore contexts(store);
+    auto loadedR = contexts.get_context(context_id);
+    ck_assert_msg(loadedR, "get_context failed: %s", result_message(loadedR));
+    ck_assert_msg(loadedR.value->has_value(), "expected persisted capability context");
+    ck_assert(loadedR.value->value().context.subject == subject_id);
+    ck_assert_uint_eq((unsigned int)loadedR.value->value().context.grants.size(), 2U);
+    ck_assert_str_eq(loadedR.value->value().context.grants[0].name.c_str(),
+                     "service.lifecycle.start");
+    ck_assert_str_eq(loadedR.value->value().context.grants[1].name.c_str(),
+                     "service.registry.read");
+
+    auto by_subjectR = contexts.list_contexts_for_subject(subject_id);
+    ck_assert_msg(by_subjectR, "list_contexts_for_subject failed: %s", result_message(by_subjectR));
+    ck_assert_uint_eq((unsigned int)by_subjectR.value->size(), 1U);
+    ck_assert(by_subjectR.value->front().context.id == context_id);
+
+    auto other_subjectR = contexts.list_contexts_for_subject(ObjectID::random());
+    ck_assert_msg(other_subjectR, "other subject lookup failed: %s", result_message(other_subjectR));
+    ck_assert_msg(other_subjectR.value->empty(), "expected no contexts for other subject");
+
+    ck_assert_msg(store.close(), "close failed");
+  }
+
+  cleanup_db_files(db_path);
+}
+END_TEST
+
+START_TEST(test_capability_context_rejects_invalid_grants)
+{
+  SqliteStore store(SqliteConfig{ .filename=":memory:", .enable_wal=false });
+  ck_assert_msg(store.open(), "open failed");
+  ck_assert_msg(store.ensure_schema(), "ensure_schema failed");
+
+  CapabilityContextStore contexts(store);
+  CapabilityContext empty_name;
+  empty_name.id = ObjectID::random();
+  empty_name.subject = ObjectID::random();
+  empty_name.grants.push_back(CapabilityGrant{""});
+
+  auto emptyR = contexts.persist_context(empty_name);
+  ck_assert_msg(!emptyR, "expected empty capability name to fail");
+  ck_assert_msg(emptyR.error.has_value(), "expected error details");
+  ck_assert_int_eq((int)emptyR.error->code, (int)ErrorCode::InvalidArgument);
+
+  CapabilityContext duplicate;
+  duplicate.id = ObjectID::random();
+  duplicate.subject = ObjectID::random();
+  duplicate.grants.push_back(CapabilityGrant{"service.registry.read"});
+  duplicate.grants.push_back(CapabilityGrant{"service.registry.read"});
+
+  auto duplicateR = contexts.persist_context(duplicate);
+  ck_assert_msg(!duplicateR, "expected duplicate capability name to fail");
+  ck_assert_msg(duplicateR.error.has_value(), "expected error details");
+  ck_assert_int_eq((int)duplicateR.error->code, (int)ErrorCode::InvalidArgument);
+
+  ck_assert_msg(store.close(), "close failed");
+}
+END_TEST
+
+Suite* capability_context_suite(void) {
+  Suite* s = suite_create("CapabilityContext");
+  TCase* tc = tcase_create("core");
+
+  tcase_add_test(tc, test_capability_context_roundtrip_and_subject_lookup);
+  tcase_add_test(tc, test_capability_context_rejects_invalid_grants);
+
+  suite_add_tcase(s, tc);
+  return s;
+}
+
+int main(void) {
+  Suite* s = capability_context_suite();
+  SRunner* sr = srunner_create(s);
+  srunner_run_all(sr, CK_NORMAL);
+  int failures = srunner_ntests_failed(sr);
+  srunner_free(sr);
+  return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- add ER-0058 capability context model and Referee persistence helper
- add round-trip, subject lookup, and invalid grant tests
- mark ER-0058 Complete in the ER ledger

## Validation
- autoreconf -fi
- ./configure
- make -j
- make check

## Autotools
- Regenerated with autoreconf -fi after updating src/Makefile.am and tests/Makefile.am.