### PR TITLE
feat: attach capability contexts to tasks

### DIFF
--- a/docs/ER/ER-0059-CEO-Task-Capability-Attachment.md
+++ b/docs/ER/ER-0059-CEO-Task-Capability-Attachment.md
@@ -1,0 +1,94 @@
+---
+GitHub-Issue: N/A
+---
+
+# ER-0059 — CEO Task Capability Attachment
+
+## Roles
+
+- Implementation Engineer: drafts and implements changes
+- System Engineer: reviews, tests, and verifies
+- Note: Only the System Engineer may mark an ER as Verified.
+
+## ER Metadata
+
+- ER ID: ER-0059
+- Title: CEO Task Capability Attachment
+- Status: Complete
+- Date: 2026-05-26
+- Owners: Mike
+- Type: Enhancement
+
+## Engineering Guidelines
+
+- Implementation language baseline: C++20 or C++24.
+- Avoid line compaction or formatting changes that risk obscuring or losing content.
+- Keep source files reasonably small. If a file grows too large to be fully replaced in a change, split it into smaller local files.
+
+## Context
+
+- Problem statement: ER-0058 added persisted capability context objects, but CEO task records cannot yet reference those contexts as task metadata.
+- Background / constraints: AR-0022 Stage D calls for capability-aware service context. This ER attaches capability context identity to tasks without introducing service-boundary enforcement.
+
+## Goals
+
+- Allow CEO task records to carry an optional capability context object ID.
+- Preserve capability context attachment through normal task lifecycle transitions.
+- Allow task listing by attached capability context.
+
+## Non-Goals
+
+- Capability enforcement.
+- Policy evaluation.
+- Sandbox isolation.
+- Validation that an attached context exists in Referee.
+
+## Scope
+
+- In scope: task metadata field for capability context object ID.
+- In scope: attach, clear, lookup, profile snapshot, and list-by-context behavior.
+- In scope: deterministic tests for attachment, lifecycle stability, and terminal-task rejection.
+- Out of scope: service-boundary authorization checks and capability grant semantics.
+
+## Requirements
+
+- Functional: non-terminal tasks can attach and clear a capability context ID.
+- Functional: task lookup, task listing, and task profile snapshots expose the attached context ID.
+- Functional: task lifecycle transitions do not drop the attached context ID.
+- Functional: terminal tasks reject attachment changes.
+- Non-functional: existing task behavior remains stable for tasks without an attached capability context.
+
+## Proposed Approach
+
+- Summary: add an optional capability context object ID to CEO task records and expose small registry helpers for attach, clear, and list-by-context operations.
+- Alternatives considered: embedding full capability grant data in task records was rejected because ER-0058 made capability context a reusable persisted object.
+
+## Acceptance Criteria
+
+- Tests verify capability context attachment is visible through task lookup.
+- Tests verify list-by-context returns attached tasks.
+- Tests verify profile snapshots include the attached context ID.
+- Tests verify lifecycle transitions preserve the attachment.
+- Tests verify terminal tasks reject attachment changes.
+
+## Risks / Open Questions
+
+- Risk: callers may mistake attachment for enforcement.
+- Question: should ER-0060 validate attached context existence before service boundary checks?
+
+## Dependencies
+
+- Dependency 1: ER-0058 Capability Context Objects and Persistence.
+- Dependency 2: ER-0057 Service Host Lifecycle and Persistent Registry.
+- Dependency 3: AR-0022 Staged Service Plane Delivery.
+
+## Implementation Notes
+
+- Notes for implementer: keep this ER metadata-only. Enforcement belongs to ER-0060.
+
+## Verification Plan
+
+- Tests to run:
+  - `make check`
+- Manual checks:
+  - create a task, attach a capability context ID, inspect the task record and profile snapshot, then run lifecycle transitions.

--- a/docs/ER/ER-Status.md
+++ b/docs/ER/ER-Status.md
@@ -68,6 +68,7 @@
 - ER-0056 — Verified
 - ER-0057 — Verified
 - ER-0058 — Complete
+- ER-0059 — Complete
 - ER-0078 — Complete
 - ER-0079 — Proposed
 - ER-0080 — Proposed

--- a/src/ceo/task_registry.cc
+++ b/src/ceo/task_registry.cc
@@ -195,6 +195,24 @@ referee::Result<void> TaskRegistry::fail_task(TaskID id, std::string reason) {
   return referee::Result<void>::ok();
 }
 
+referee::Result<void> TaskRegistry::attach_capability_context(
+    TaskID id,
+    referee::ObjectID capability_context_id) {
+  auto* rec = find_task(id);
+  if (!rec) return referee::Result<void>::err("task not found");
+  if (is_terminal(rec->state)) return referee::Result<void>::err("task already terminal");
+  rec->capability_context_id = capability_context_id;
+  return referee::Result<void>::ok();
+}
+
+referee::Result<void> TaskRegistry::clear_capability_context(TaskID id) {
+  auto* rec = find_task(id);
+  if (!rec) return referee::Result<void>::err("task not found");
+  if (is_terminal(rec->state)) return referee::Result<void>::err("task already terminal");
+  rec->capability_context_id.reset();
+  return referee::Result<void>::ok();
+}
+
 referee::Result<std::optional<TaskRecord>> TaskRegistry::get_task(TaskID id) const {
   const auto* rec = find_task(id);
   if (!rec) return referee::Result<std::optional<TaskRecord>>::ok(std::nullopt);
@@ -205,6 +223,22 @@ referee::Result<std::vector<TaskRecord>> TaskRegistry::list_tasks() const {
   std::vector<TaskRecord> out;
   out.reserve(tasks_.size());
   for (const auto& kv : tasks_) out.push_back(kv.second);
+  std::sort(out.begin(), out.end(), [](const TaskRecord& a, const TaskRecord& b) {
+    return a.id < b.id;
+  });
+  return referee::Result<std::vector<TaskRecord>>::ok(std::move(out));
+}
+
+referee::Result<std::vector<TaskRecord>> TaskRegistry::list_tasks_for_capability_context(
+    referee::ObjectID capability_context_id) const {
+  std::vector<TaskRecord> out;
+  out.reserve(tasks_.size());
+  for (const auto& kv : tasks_) {
+    if (kv.second.capability_context_id.has_value()
+        && kv.second.capability_context_id.value() == capability_context_id) {
+      out.push_back(kv.second);
+    }
+  }
   std::sort(out.begin(), out.end(), [](const TaskRecord& a, const TaskRecord& b) {
     return a.id < b.id;
   });
@@ -225,6 +259,7 @@ TaskProfileSnapshot TaskRegistry::profile_snapshot() const {
     TaskProfile profile;
     profile.id = rec.id;
     profile.object_id = rec.object_id;
+    profile.capability_context_id = rec.capability_context_id;
     profile.name = rec.name;
     profile.mode = rec.mode;
     profile.state = rec.state;

--- a/src/ceo/task_registry.h
+++ b/src/ceo/task_registry.h
@@ -46,6 +46,7 @@ struct ChildLink {
 struct TaskRecord {
   TaskID id{0};
   referee::ObjectID object_id{};
+  std::optional<referee::ObjectID> capability_context_id;
   std::optional<TaskID> parent;
   std::vector<ChildLink> children;
   TaskState state{TaskState::Created};
@@ -56,6 +57,7 @@ struct TaskRecord {
 struct TaskProfile {
   TaskID id{0};
   referee::ObjectID object_id{};
+  std::optional<referee::ObjectID> capability_context_id;
   std::string name;
   TaskMode mode{TaskMode::Inline};
   TaskState state{TaskState::Created};
@@ -124,9 +126,13 @@ public:
   referee::Result<void> kill_task(TaskID id);
   referee::Result<void> complete_task(TaskID id);
   referee::Result<void> fail_task(TaskID id, std::string reason);
+  referee::Result<void> attach_capability_context(TaskID id, referee::ObjectID capability_context_id);
+  referee::Result<void> clear_capability_context(TaskID id);
 
   referee::Result<std::optional<TaskRecord>> get_task(TaskID id) const;
   referee::Result<std::vector<TaskRecord>> list_tasks() const;
+  referee::Result<std::vector<TaskRecord>> list_tasks_for_capability_context(
+      referee::ObjectID capability_context_id) const;
   TaskProfileSnapshot profile_snapshot() const;
   TaskTraceSnapshot trace_snapshot() const;
   void clear_trace();

--- a/tests/test_ceo_tasks.cc
+++ b/tests/test_ceo_tasks.cc
@@ -121,6 +121,67 @@ START_TEST(test_create_start_stop)
 }
 END_TEST
 
+START_TEST(test_capability_context_attachment)
+{
+  TaskRegistry registry;
+  auto task = registry.create_task(referee::ObjectID::random(), std::nullopt, "cap-task",
+                                   TaskMode::Service);
+  ck_assert_msg(task, "create task failed");
+
+  auto context_id = referee::ObjectID::random();
+  ck_assert_msg(registry.attach_capability_context(task.value->id, context_id),
+                "attach_capability_context failed");
+
+  auto lookup = registry.get_task(task.value->id);
+  ck_assert_msg(lookup, "get_task failed");
+  ck_assert_msg(lookup.value->has_value(), "expected task record");
+  ck_assert_msg(lookup.value->value().capability_context_id.has_value(),
+                "expected capability context attachment");
+  ck_assert(lookup.value->value().capability_context_id.value() == context_id);
+
+  auto by_context = registry.list_tasks_for_capability_context(context_id);
+  ck_assert_msg(by_context, "list_tasks_for_capability_context failed");
+  ck_assert_uint_eq((unsigned int)by_context.value->size(), 1U);
+  ck_assert_uint_eq((unsigned int)by_context.value->front().id, (unsigned int)task.value->id);
+
+  auto profile = registry.profile_snapshot();
+  ck_assert_uint_eq((unsigned int)profile.tasks.size(), 1U);
+  ck_assert_msg(profile.tasks.front().capability_context_id.has_value(),
+                "expected profile capability context attachment");
+  ck_assert(profile.tasks.front().capability_context_id.value() == context_id);
+
+  ck_assert_msg(registry.start_task(task.value->id), "start_task failed");
+  ck_assert_msg(registry.wait_task(task.value->id), "wait_task failed");
+  ck_assert_msg(registry.resume_task(task.value->id), "resume_task failed");
+
+  auto after_lifecycle = registry.get_task(task.value->id);
+  ck_assert_msg(after_lifecycle, "get_task after lifecycle failed");
+  ck_assert(after_lifecycle.value->value().capability_context_id.value() == context_id);
+
+  ck_assert_msg(registry.clear_capability_context(task.value->id),
+                "clear_capability_context failed");
+  auto cleared = registry.get_task(task.value->id);
+  ck_assert_msg(cleared, "get_task after clear failed");
+  ck_assert_msg(!cleared.value->value().capability_context_id.has_value(),
+                "expected cleared capability context");
+}
+END_TEST
+
+START_TEST(test_capability_context_terminal_task_rejects_attachment_changes)
+{
+  TaskRegistry registry;
+  auto task = registry.spawn_task(referee::ObjectID::random());
+  ck_assert_msg(task, "spawn task failed");
+  ck_assert_msg(registry.complete_task(task.value->id), "complete_task failed");
+
+  auto attach = registry.attach_capability_context(task.value->id, referee::ObjectID::random());
+  ck_assert_msg(!attach, "expected terminal task attachment to fail");
+
+  auto clear = registry.clear_capability_context(task.value->id);
+  ck_assert_msg(!clear, "expected terminal task clear to fail");
+}
+END_TEST
+
 START_TEST(test_task_comms_open_close)
 {
   TaskRegistry registry;
@@ -201,6 +262,8 @@ Suite* ceo_task_suite(void) {
   tcase_add_test(tc, test_wait_and_resume);
   tcase_add_test(tc, test_invalid_parent);
   tcase_add_test(tc, test_create_start_stop);
+  tcase_add_test(tc, test_capability_context_attachment);
+  tcase_add_test(tc, test_capability_context_terminal_task_rejects_attachment_changes);
   tcase_add_test(tc, test_task_comms_open_close);
   tcase_add_test(tc, test_supervision_tree_detach_on_terminal);
   tcase_add_test(tc, test_long_run_task_stability);


### PR DESCRIPTION
## Summary
- add optional capability context attachment to CEO task records and profiles
- add attach, clear, and list-by-context registry helpers
- add ER-0059 doc and mark ER-0059 Complete

## Validation
- make -j
- make check

## Autotools
- No Autotools source files changed; no regeneration was needed.