### PR TITLE
feat: enforce service boundary capabilities

### DIFF
--- a/docs/ER/ER-0060-Service-Boundary-Capability-Enforcement.md
+++ b/docs/ER/ER-0060-Service-Boundary-Capability-Enforcement.md
@@ -1,0 +1,97 @@
+---
+GitHub-Issue: N/A
+---
+
+# ER-0060 — Service Boundary Capability Enforcement
+
+## Roles
+
+- Implementation Engineer: drafts and implements changes
+- System Engineer: reviews, tests, and verifies
+- Note: Only the System Engineer may mark an ER as Verified.
+
+## ER Metadata
+
+- ER ID: ER-0060
+- Title: Service Boundary Capability Enforcement
+- Status: Complete
+- Date: 2026-05-26
+- Owners: Mike
+- Type: Enhancement
+
+## Engineering Guidelines
+
+- Implementation language baseline: C++20 or C++24.
+- Avoid line compaction or formatting changes that risk obscuring or losing content.
+- Keep source files reasonably small. If a file grows too large to be fully replaced in a change, split it into smaller local files.
+
+## Context
+
+- Problem statement: ER-0058 added persisted capability contexts and ER-0059 attached capability context identity to tasks, but service IPC still accepts calls without service-boundary capability checks.
+- Background / constraints: AR-0022 Stage D calls for capability-aware service context, sandbox identifiers, service boundary checks, and minimal policy enforcement hooks.
+
+## Goals
+
+- Allow services and declared endpoints to expose required capability grants.
+- Enforce required grants before dispatching service IPC requests.
+- Use persisted capability context records as the initial authority source.
+- Preserve existing IPC behavior for services with no required grants.
+
+## Non-Goals
+
+- Full policy engine.
+- Sandbox identity and isolation semantics.
+- Task-registry-based provenance checks.
+- Network or distributed service authorization.
+
+## Scope
+
+- In scope: required grant metadata on service descriptors and endpoint descriptors.
+- In scope: service-boundary authorizer abstraction.
+- In scope: persisted capability-context authorizer using sender subject lookup.
+- In scope: IPC rejection when required grants are missing.
+- Out of scope: broader policy taxonomy, sandbox enforcement, and task-attached context validation.
+
+## Requirements
+
+- Functional: a service can declare required grants for boundary access.
+- Functional: a declared endpoint can declare additional required grants.
+- Functional: IPC rejects requests when the sender has no persisted capability context with the required grants.
+- Functional: IPC allows requests when the sender's persisted capability contexts satisfy the required grants.
+- Non-functional: services without required grants continue to dispatch as before.
+
+## Proposed Approach
+
+- Summary: add explicit grant metadata to service descriptors and endpoints, introduce a small `ServiceBoundaryAuthorizer` hook, and implement a `CapabilityContextAuthorizer` that checks persisted grants attached to the request sender subject.
+- Alternatives considered: hidden service-name grant conventions were rejected because service requirements should be inspectable. Coupling IPC directly to CEO task registry was deferred because current message envelopes carry sender object identity, not task identity.
+
+## Acceptance Criteria
+
+- Tests verify descriptor-level required grants reject missing sender grants.
+- Tests verify descriptor-level required grants allow matching persisted sender grants.
+- Tests verify endpoint-level required grants reject and allow when a request identifies a declared endpoint.
+- Existing IPC tests continue to pass for unrestricted services.
+
+## Risks / Open Questions
+
+- Risk: sender-subject lookup does not prove task provenance; task-aware validation remains future hardening.
+- Risk: endpoint metadata enforcement only applies when the request identifies a declared endpoint.
+- Question: should ER-0061 make sandbox identity mandatory for service-boundary checks?
+
+## Dependencies
+
+- Dependency 1: ER-0058 Capability Context Objects and Persistence.
+- Dependency 2: ER-0059 CEO Task Capability Attachment.
+- Dependency 3: AR-0022 Staged Service Plane Delivery.
+
+## Implementation Notes
+
+- Notes for implementer: keep the authorizer small and fail closed only when services declare required grants.
+- Notes for implementer: preserve unrestricted IPC behavior for service descriptors with no required grants.
+
+## Verification Plan
+
+- Tests to run:
+  - `make check`
+- Manual checks:
+  - register a service with required grants, send a request from a sender without a matching persisted capability context, then persist a matching context and retry.

--- a/docs/ER/ER-Status.md
+++ b/docs/ER/ER-Status.md
@@ -69,6 +69,7 @@
 - ER-0057 — Verified
 - ER-0058 — Complete
 - ER-0059 — Complete
+- ER-0060 — Complete
 - ER-0078 — Complete
 - ER-0079 — Proposed
 - ER-0080 — Proposed

--- a/src/services/service.cc
+++ b/src/services/service.cc
@@ -1,11 +1,34 @@
 #include "services/service.h"
 
+#include "services/capability_context.h"
+
 #include <chrono>
+#include <unordered_set>
 
 namespace iris::service {
 
 static std::string id_key(const referee::ObjectID& id) {
   return id.to_hex();
+}
+
+static bool endpoint_matches(const Endpoint& declared, const Endpoint& requested) {
+  if (!declared.name.empty() && !requested.name.empty() && declared.name == requested.name) {
+    return true;
+  }
+  if (declared.type.has_value() && requested.type.has_value() &&
+      declared.type.value() == requested.type.value()) {
+    return true;
+  }
+  return false;
+}
+
+static std::optional<Endpoint> find_declared_endpoint(const ServiceDescriptor& service,
+                                                      const std::optional<Endpoint>& requested) {
+  if (!requested.has_value()) return std::nullopt;
+  for (const auto& endpoint : service.endpoints) {
+    if (endpoint_matches(endpoint, requested.value())) return endpoint;
+  }
+  return std::nullopt;
 }
 
 MessageEnvelope make_request_to_object(referee::ObjectID sender,
@@ -127,37 +150,94 @@ ServiceObject* ServiceRegistry::handler_for(const referee::ObjectID& id) const {
   return it->second.handler;
 }
 
+CapabilityContextAuthorizer::CapabilityContextAuthorizer(CapabilityContextStore& contexts)
+    : contexts_(contexts) {}
+
+referee::Result<void> CapabilityContextAuthorizer::authorize(
+    const MessageEnvelope& request,
+    const ServiceDescriptor& service,
+    const std::optional<Endpoint>& endpoint) {
+  std::vector<std::string> required;
+  required.reserve(service.required_grants.size() +
+                   (endpoint.has_value() ? endpoint->required_grants.size() : 0));
+  for (const auto& grant : service.required_grants) required.push_back(grant);
+  if (endpoint.has_value()) {
+    for (const auto& grant : endpoint->required_grants) required.push_back(grant);
+  }
+
+  if (required.empty()) return referee::Result<void>::ok();
+
+  auto contextsR = contexts_.list_contexts_for_subject(request.sender);
+  if (!contextsR) return referee::Result<void>::err(contextsR.error.value());
+
+  std::unordered_set<std::string> granted;
+  for (const auto& record : contextsR.value.value()) {
+    for (const auto& grant : record.context.grants) {
+      granted.insert(grant.name);
+    }
+  }
+
+  for (const auto& grant : required) {
+    if (granted.find(grant) == granted.end()) {
+      return referee::Result<void>::err(referee::ErrorCode::FailedPrecondition,
+                                        "missing capability grant: " + grant);
+    }
+  }
+
+  return referee::Result<void>::ok();
+}
+
 IpcService::IpcService(ServiceRegistry& registry) : registry_(registry) {}
 
-ServiceObject* IpcService::resolve_handler(const MessageEnvelope& request) const {
-  if (request.recipient.has_value()) return registry_.handler_for(request.recipient.value());
-  if (!request.endpoint.has_value()) return nullptr;
+IpcService::IpcService(ServiceRegistry& registry, ServiceBoundaryAuthorizer* authorizer)
+    : registry_(registry), authorizer_(authorizer) {}
+
+std::optional<IpcService::ResolvedService> IpcService::resolve_service(
+    const MessageEnvelope& request) const {
+  if (request.recipient.has_value()) {
+    auto* handler = registry_.handler_for(request.recipient.value());
+    if (!handler) return std::nullopt;
+    auto descriptor = handler->descriptor();
+    return ResolvedService{descriptor, find_declared_endpoint(descriptor, request.endpoint), handler};
+  }
+  if (!request.endpoint.has_value()) return std::nullopt;
 
   const auto& endpoint = request.endpoint.value();
   if (!endpoint.name.empty()) {
     auto resolved = registry_.resolve_by_name(endpoint.name);
-    if (!resolved || !resolved.value->has_value()) return nullptr;
-    return registry_.handler_for(resolved.value->value().id);
+    if (!resolved || !resolved.value->has_value()) return std::nullopt;
+    const auto& descriptor = resolved.value->value();
+    auto* handler = registry_.handler_for(descriptor.id);
+    if (!handler) return std::nullopt;
+    return ResolvedService{descriptor, find_declared_endpoint(descriptor, request.endpoint), handler};
   }
 
   if (endpoint.type.has_value()) {
     auto resolved = registry_.resolve_by_type(endpoint.type.value());
-    if (!resolved || !resolved.value->has_value()) return nullptr;
-    return registry_.handler_for(resolved.value->value().id);
+    if (!resolved || !resolved.value->has_value()) return std::nullopt;
+    const auto& descriptor = resolved.value->value();
+    auto* handler = registry_.handler_for(descriptor.id);
+    if (!handler) return std::nullopt;
+    return ResolvedService{descriptor, find_declared_endpoint(descriptor, request.endpoint), handler};
   }
 
-  return nullptr;
+  return std::nullopt;
 }
 
 referee::Result<MessageEnvelope> IpcService::send_request(const MessageEnvelope& request,
                                                           std::chrono::milliseconds timeout) {
   if (timeout.count() <= 0) return referee::Result<MessageEnvelope>::err("timeout");
 
-  auto* handler = resolve_handler(request);
-  if (!handler) return referee::Result<MessageEnvelope>::err("service not found");
+  auto resolved = resolve_service(request);
+  if (!resolved.has_value()) return referee::Result<MessageEnvelope>::err("service not found");
+
+  if (authorizer_) {
+    auto authR = authorizer_->authorize(request, resolved->descriptor, resolved->endpoint);
+    if (!authR) return referee::Result<MessageEnvelope>::err(authR.error.value());
+  }
 
   auto start = std::chrono::steady_clock::now();
-  auto response = handler->handle_message(request);
+  auto response = resolved->handler->handle_message(request);
   auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start);
 
   if (elapsed > timeout) return referee::Result<MessageEnvelope>::err("timeout");

--- a/src/services/service.h
+++ b/src/services/service.h
@@ -12,9 +12,12 @@
 
 namespace iris::service {
 
+class CapabilityContextStore;
+
 struct Endpoint {
   std::string name;
   std::optional<referee::TypeID> type;
+  std::vector<std::string> required_grants;
 };
 
 struct MessageEnvelope {
@@ -48,6 +51,7 @@ struct ServiceDescriptor {
   referee::ObjectID id{};
   referee::TypeID type{};
   std::string name;
+  std::vector<std::string> required_grants;
   std::vector<Endpoint> endpoints;
 };
 
@@ -79,17 +83,45 @@ private:
   std::unordered_map<std::uint64_t, std::string> by_type_;
 };
 
+class ServiceBoundaryAuthorizer {
+public:
+  virtual ~ServiceBoundaryAuthorizer() = default;
+  virtual referee::Result<void> authorize(const MessageEnvelope& request,
+                                          const ServiceDescriptor& service,
+                                          const std::optional<Endpoint>& endpoint) = 0;
+};
+
+class CapabilityContextAuthorizer final : public ServiceBoundaryAuthorizer {
+public:
+  explicit CapabilityContextAuthorizer(CapabilityContextStore& contexts);
+
+  referee::Result<void> authorize(const MessageEnvelope& request,
+                                  const ServiceDescriptor& service,
+                                  const std::optional<Endpoint>& endpoint) override;
+
+private:
+  CapabilityContextStore& contexts_;
+};
+
 class IpcService {
 public:
   explicit IpcService(ServiceRegistry& registry);
+  IpcService(ServiceRegistry& registry, ServiceBoundaryAuthorizer* authorizer);
 
   referee::Result<MessageEnvelope> send_request(const MessageEnvelope& request,
                                                 std::chrono::milliseconds timeout);
 
 private:
-  ServiceObject* resolve_handler(const MessageEnvelope& request) const;
+  struct ResolvedService {
+    ServiceDescriptor descriptor{};
+    std::optional<Endpoint> endpoint;
+    ServiceObject* handler{nullptr};
+  };
+
+  std::optional<ResolvedService> resolve_service(const MessageEnvelope& request) const;
 
   ServiceRegistry& registry_;
+  ServiceBoundaryAuthorizer* authorizer_{nullptr};
 };
 
 } // namespace iris::service

--- a/tests/test_service_ipc.cc
+++ b/tests/test_service_ipc.cc
@@ -6,10 +6,13 @@ extern "C" {
 #endif
 
 #include "referee/referee.h"
+#include "services/capability_context.h"
 #include "services/service.h"
 
 #include <chrono>
 #include <string>
+#include <utility>
+#include <vector>
 
 using namespace referee;
 using namespace iris::service;
@@ -23,14 +26,20 @@ const char* result_message(const Result<T>& r) {
 
 class EchoService final : public ServiceObject {
 public:
-  EchoService(ObjectID id, TypeID type, std::string name)
+  EchoService(ObjectID id,
+              TypeID type,
+              std::string name,
+              std::vector<std::string> required_grants = {},
+              std::vector<std::string> endpoint_required_grants = {})
       : ack_type_{0xACCA0001ULL} {
     desc_.id = id;
     desc_.type = type;
     desc_.name = std::move(name);
+    desc_.required_grants = std::move(required_grants);
     Endpoint ep;
     ep.name = "echo";
     ep.type = TypeID{0xE001ULL};
+    ep.required_grants = std::move(endpoint_required_grants);
     desc_.endpoints.push_back(ep);
   }
 
@@ -47,6 +56,16 @@ private:
   ServiceDescriptor desc_{};
   TypeID ack_type_{};
 };
+
+CapabilityContext make_context(ObjectID id, ObjectID subject, std::vector<std::string> grants) {
+  CapabilityContext context;
+  context.id = id;
+  context.subject = subject;
+  for (auto& grant : grants) {
+    context.grants.push_back(CapabilityGrant{std::move(grant)});
+  }
+  return context;
+}
 
 } // namespace
 
@@ -104,12 +123,92 @@ START_TEST(test_ipc_send_receive_ack_and_timeout)
 }
 END_TEST
 
+START_TEST(test_ipc_enforces_descriptor_required_grants)
+{
+  SqliteStore store(SqliteConfig{ .filename=":memory:", .enable_wal=false });
+  ck_assert_msg(store.open(), "open failed");
+  ck_assert_msg(store.ensure_schema(), "ensure_schema failed");
+
+  CapabilityContextStore contexts(store);
+  CapabilityContextAuthorizer authorizer(contexts);
+
+  ServiceRegistry registry;
+  EchoService svc(ObjectID::random(), TypeID{0x9003ULL}, "restricted-service",
+                  {"service.echo.call"});
+  ck_assert_msg(registry.register_service(svc.descriptor(), &svc), "register_service failed");
+
+  IpcService ipc(registry, &authorizer);
+  Endpoint endpoint;
+  endpoint.name = "restricted-service";
+
+  auto sender = ObjectID::random();
+  auto request = make_request_to_endpoint(sender, endpoint, TypeID{0xBEEF0002ULL}, {});
+
+  auto denied = ipc.send_request(request, std::chrono::milliseconds(5));
+  ck_assert_msg(!denied, "expected missing capability grant to fail");
+  ck_assert_msg(denied.error.has_value(), "expected error details");
+  ck_assert_int_eq((int)denied.error->code, (int)ErrorCode::FailedPrecondition);
+
+  auto context = make_context(ObjectID::random(), sender, {"service.echo.call"});
+  auto savedR = contexts.persist_context(context);
+  ck_assert_msg(savedR, "persist_context failed: %s", result_message(savedR));
+
+  auto allowed = ipc.send_request(request, std::chrono::milliseconds(5));
+  ck_assert_msg(allowed, "send_request with capability failed: %s", result_message(allowed));
+  ck_assert(allowed.value->correlation_id == request.correlation_id);
+
+  ck_assert_msg(store.close(), "close failed");
+}
+END_TEST
+
+START_TEST(test_ipc_enforces_endpoint_required_grants_for_declared_endpoint)
+{
+  SqliteStore store(SqliteConfig{ .filename=":memory:", .enable_wal=false });
+  ck_assert_msg(store.open(), "open failed");
+  ck_assert_msg(store.ensure_schema(), "ensure_schema failed");
+
+  CapabilityContextStore contexts(store);
+  CapabilityContextAuthorizer authorizer(contexts);
+
+  ServiceRegistry registry;
+  EchoService svc(ObjectID::random(), TypeID{0x9004ULL}, "endpoint-service", {},
+                  {"service.echo.endpoint"});
+  ck_assert_msg(registry.register_service(svc.descriptor(), &svc), "register_service failed");
+
+  IpcService ipc(registry, &authorizer);
+  Endpoint endpoint;
+  endpoint.name = "echo";
+
+  auto sender = ObjectID::random();
+  auto request = make_request_to_object(sender, svc.descriptor().id, TypeID{0xBEEF0003ULL}, {});
+  request.endpoint = endpoint;
+
+  auto denied = ipc.send_request(request, std::chrono::milliseconds(5));
+  ck_assert_msg(!denied, "expected missing endpoint capability grant to fail");
+  ck_assert_msg(denied.error.has_value(), "expected error details");
+  ck_assert_int_eq((int)denied.error->code, (int)ErrorCode::FailedPrecondition);
+
+  auto context = make_context(ObjectID::random(), sender, {"service.echo.endpoint"});
+  auto savedR = contexts.persist_context(context);
+  ck_assert_msg(savedR, "persist_context failed: %s", result_message(savedR));
+
+  auto allowed = ipc.send_request(request, std::chrono::milliseconds(5));
+  ck_assert_msg(allowed, "send_request with endpoint capability failed: %s",
+                result_message(allowed));
+  ck_assert(allowed.value->correlation_id == request.correlation_id);
+
+  ck_assert_msg(store.close(), "close failed");
+}
+END_TEST
+
 Suite* service_ipc_suite(void) {
   Suite* s = suite_create("ServiceIPC");
   TCase* tc = tcase_create("core");
 
   tcase_add_test(tc, test_service_registry_register_resolve_unregister);
   tcase_add_test(tc, test_ipc_send_receive_ack_and_timeout);
+  tcase_add_test(tc, test_ipc_enforces_descriptor_required_grants);
+  tcase_add_test(tc, test_ipc_enforces_endpoint_required_grants_for_declared_endpoint);
 
   suite_add_tcase(s, tc);
   return s;


### PR DESCRIPTION
## Summary
- add ER-0060 documentation and status entry
- add service and endpoint required-grant metadata
- add a service-boundary authorizer backed by persisted capability contexts
- enforce required grants in IPC before service dispatch
- add IPC coverage for descriptor and endpoint grants

## Validation
- make -C tests check TESTS=test_service_ipc
- make check

## Notes
- no Autotools regeneration was needed
- task-registry provenance and sandbox identity remain out of scope for ER-0060