### PR TITLE
chore: untrack generated test artifacts

### DIFF
--- a/tests/test_referee_core.log
+++ b/tests/test_referee_core.log
@@ -1,3 +1,0 @@
-Running suite(s): RefereeCore
-100%: Checks: 2, Failures: 0, Errors: 0
-PASS test_referee_core (exit status: 0)

--- a/tests/test_referee_core.trs
+++ b/tests/test_referee_core.trs
@@ -1,4 +1,0 @@
-:test-result: PASS
-:global-test-result: PASS
-:recheck: no
-:copy-in-global-log: no


### PR DESCRIPTION
## Summary
- untrack generated Automake test result files already covered by .gitignore
- leave local generated files on disk

## Validation
- not run; metadata-only cleanup