### PR TITLE
feat: add sandbox identity hooks

### DIFF
--- a/docs/ER/ER-0061-Sandbox-Identity-and-Service-Isolation-Hooks.md
+++ b/docs/ER/ER-0061-Sandbox-Identity-and-Service-Isolation-Hooks.md
@@ -1,0 +1,96 @@
+---
+GitHub-Issue: N/A
+---
+
+# ER-0061 — Sandbox Identity and Service Isolation Hooks
+
+## Roles
+
+- Implementation Engineer: drafts and implements changes
+- System Engineer: reviews, tests, and verifies
+- Note: Only the System Engineer may mark an ER as Verified.
+
+## ER Metadata
+
+- ER ID: ER-0061
+- Title: Sandbox Identity and Service Isolation Hooks
+- Status: Complete
+- Date: 2026-05-26
+- Owners: Mike
+- Type: Enhancement
+
+## Engineering Guidelines
+
+- Implementation language baseline: C++20 or C++24.
+- Avoid line compaction or formatting changes that risk obscuring or losing content.
+- Keep source files reasonably small. If a file grows too large to be fully replaced in a change, split it into smaller local files.
+
+## Context
+
+- Problem statement: ER-0058 allowed capability contexts to reference an optional sandbox object ID, and ER-0060 added service-boundary capability enforcement, but sandbox identity is still only an opaque ID with no persisted metadata or IPC hook.
+- Background / constraints: AR-0022 Stage D calls for sandbox identifiers and service boundary checks. The System Engineer selected a metadata/hooks-only ER-0061 slice, with sandbox enforcement deferred.
+
+## Goals
+
+- Introduce first-class persisted sandbox identity metadata.
+- Allow sandbox identity to be attached to service IPC envelopes.
+- Preserve sandbox identity through simple request/response flows.
+- Keep ER-0060 capability enforcement unchanged.
+
+## Non-Goals
+
+- Mandatory sandbox identity checks at service boundaries.
+- Sandbox membership enforcement.
+- Process, filesystem, memory, network, or OS-level isolation.
+- Full policy engine behavior.
+
+## Scope
+
+- In scope: sandbox identity ID, display name, and attached subject object IDs.
+- In scope: deterministic Referee persistence and reload for sandbox identity records.
+- In scope: subject lookup for sandbox identity records.
+- In scope: optional sandbox identity metadata on service message envelopes.
+- Out of scope: rejecting service requests based on sandbox identity.
+
+## Requirements
+
+- Functional: sandbox identity records can be persisted and reloaded through Referee.
+- Functional: sandbox identity records can be listed by attached subject object ID.
+- Functional: empty sandbox names and duplicate subject attachments are rejected deterministically.
+- Functional: service responses preserve request sandbox identity metadata.
+- Non-functional: existing service authorization behavior remains grant-only unless later ERs add sandbox enforcement.
+
+## Proposed Approach
+
+- Summary: extend the capability context store with sandbox identity records and add an optional sandbox ID field to service IPC envelopes.
+- Alternatives considered: making sandbox identity mandatory in ER-0060 authorization was rejected for this slice because service isolation semantics are not defined yet.
+
+## Acceptance Criteria
+
+- Tests verify sandbox identity persistence survives store reopen.
+- Tests verify lookup by subject returns attached sandbox identity records.
+- Tests verify invalid sandbox metadata is rejected.
+- Tests verify service IPC response envelopes preserve sandbox identity metadata.
+
+## Risks / Open Questions
+
+- Risk: callers may mistake sandbox identity metadata for isolation enforcement.
+- Question: which ER should define mandatory sandbox membership checks at service boundaries?
+
+## Dependencies
+
+- Dependency 1: ER-0058 Capability Context Objects and Persistence.
+- Dependency 2: ER-0060 Service Boundary Capability Enforcement.
+- Dependency 3: AR-0022 Staged Service Plane Delivery.
+
+## Implementation Notes
+
+- Notes for implementer: keep this ER metadata/hooks only.
+- Notes for implementer: do not change ER-0060 grant enforcement semantics.
+
+## Verification Plan
+
+- Tests to run:
+  - `make check`
+- Manual checks:
+  - persist a sandbox identity, reload it, attach its ID to an IPC request, and inspect the response envelope.

--- a/docs/ER/ER-Status.md
+++ b/docs/ER/ER-Status.md
@@ -70,6 +70,7 @@
 - ER-0058 — Complete
 - ER-0059 — Complete
 - ER-0060 — Complete
+- ER-0061 — Complete
 - ER-0078 — Complete
 - ER-0079 — Proposed
 - ER-0080 — Proposed

--- a/src/services/capability_context.cc
+++ b/src/services/capability_context.cc
@@ -32,6 +32,26 @@ referee::Result<CapabilityContext> validate_context(CapabilityContext context) {
   return referee::Result<CapabilityContext>::ok(std::move(context));
 }
 
+referee::Result<SandboxIdentity> validate_sandbox(SandboxIdentity sandbox) {
+  if (sandbox.name.empty()) {
+    return referee::Result<SandboxIdentity>::err(referee::ErrorCode::InvalidArgument,
+                                                 "sandbox name is empty");
+  }
+
+  std::sort(sandbox.subjects.begin(), sandbox.subjects.end(),
+            [](const referee::ObjectID& lhs, const referee::ObjectID& rhs) {
+              return lhs.to_hex() < rhs.to_hex();
+            });
+  auto duplicate = std::adjacent_find(sandbox.subjects.begin(), sandbox.subjects.end());
+  if (duplicate != sandbox.subjects.end()) {
+    return referee::Result<SandboxIdentity>::err(
+        referee::ErrorCode::InvalidArgument,
+        "duplicate sandbox subject: " + duplicate->to_hex());
+  }
+
+  return referee::Result<SandboxIdentity>::ok(std::move(sandbox));
+}
+
 nlohmann::json context_to_json(const CapabilityContext& context) {
   nlohmann::json j;
   j["subject"] = context.subject.to_hex();
@@ -39,6 +59,45 @@ nlohmann::json context_to_json(const CapabilityContext& context) {
   j["grants"] = nlohmann::json::array();
   for (const auto& grant : context.grants) {
     j["grants"].push_back(grant.name);
+  }
+  return j;
+}
+
+referee::Result<SandboxIdentity> sandbox_from_json(referee::ObjectID id,
+                                                   const nlohmann::json& j) {
+  if (!j.is_object()) {
+    return referee::Result<SandboxIdentity>::err(referee::ErrorCode::CorruptData,
+                                                 "sandbox payload must be an object");
+  }
+  if (!j.contains("name")) {
+    return referee::Result<SandboxIdentity>::err(referee::ErrorCode::CorruptData,
+                                                 "sandbox missing name");
+  }
+  if (!j.contains("subjects") || !j.at("subjects").is_array()) {
+    return referee::Result<SandboxIdentity>::err(referee::ErrorCode::CorruptData,
+                                                 "sandbox subjects must be an array");
+  }
+
+  SandboxIdentity sandbox;
+  sandbox.id = id;
+  try {
+    sandbox.name = j.at("name").get<std::string>();
+    for (const auto& item : j.at("subjects")) {
+      sandbox.subjects.push_back(referee::ObjectID::from_hex(item.get<std::string>()));
+    }
+  } catch (const std::exception& ex) {
+    return referee::Result<SandboxIdentity>::err(referee::ErrorCode::CorruptData, ex.what());
+  }
+
+  return validate_sandbox(std::move(sandbox));
+}
+
+nlohmann::json sandbox_to_json(const SandboxIdentity& sandbox) {
+  nlohmann::json j;
+  j["name"] = sandbox.name;
+  j["subjects"] = nlohmann::json::array();
+  for (const auto& subject : sandbox.subjects) {
+    j["subjects"].push_back(subject.to_hex());
   }
   return j;
 }
@@ -95,9 +154,104 @@ referee::Result<CapabilityContextRecord> record_from_object(const referee::Objec
   }
 }
 
+referee::Result<SandboxIdentityRecord> sandbox_record_from_object(
+    const referee::ObjectRecord& rec) {
+  try {
+    auto json = nlohmann::json::from_cbor(rec.payload_cbor);
+    auto sandboxR = sandbox_from_json(rec.ref.id, json);
+    if (!sandboxR) {
+      return referee::Result<SandboxIdentityRecord>::err(sandboxR.error.value());
+    }
+    SandboxIdentityRecord out;
+    out.ref = rec.ref;
+    out.sandbox = std::move(sandboxR.value.value());
+    return referee::Result<SandboxIdentityRecord>::ok(std::move(out));
+  } catch (const std::exception& ex) {
+    return referee::Result<SandboxIdentityRecord>::err(referee::ErrorCode::CorruptData,
+                                                       ex.what());
+  }
+}
+
 } // namespace
 
 CapabilityContextStore::CapabilityContextStore(referee::SqliteStore& store) : store_(store) {}
+
+referee::Result<SandboxIdentityRecord> CapabilityContextStore::persist_sandbox(
+    const SandboxIdentity& sandbox) {
+  auto normalizedR = validate_sandbox(sandbox);
+  if (!normalizedR) {
+    return referee::Result<SandboxIdentityRecord>::err(normalizedR.error.value());
+  }
+
+  const auto& normalized = normalizedR.value.value();
+  auto payload = nlohmann::json::to_cbor(sandbox_to_json(normalized));
+  auto recR = store_.create_object_with_id(normalized.id,
+                                           kSandboxIdentityType,
+                                           referee::ObjectID{},
+                                           payload);
+  if (!recR) return referee::Result<SandboxIdentityRecord>::err(recR.error.value());
+
+  SandboxIdentityRecord out;
+  out.ref = recR.value->ref;
+  out.sandbox = normalized;
+  return referee::Result<SandboxIdentityRecord>::ok(std::move(out));
+}
+
+referee::Result<std::optional<SandboxIdentityRecord>> CapabilityContextStore::get_sandbox(
+    referee::ObjectID id) {
+  auto recR = store_.get_latest(id);
+  if (!recR) return referee::Result<std::optional<SandboxIdentityRecord>>::err(recR.error.value());
+  if (!recR.value->has_value()) {
+    return referee::Result<std::optional<SandboxIdentityRecord>>::ok(std::nullopt);
+  }
+  if (recR.value->value().type != kSandboxIdentityType) {
+    return referee::Result<std::optional<SandboxIdentityRecord>>::err(
+        referee::ErrorCode::InvalidArgument,
+        "object is not a sandbox identity");
+  }
+
+  auto recordR = sandbox_record_from_object(recR.value->value());
+  if (!recordR) {
+    return referee::Result<std::optional<SandboxIdentityRecord>>::err(recordR.error.value());
+  }
+  return referee::Result<std::optional<SandboxIdentityRecord>>::ok(recordR.value.value());
+}
+
+referee::Result<std::vector<SandboxIdentityRecord>> CapabilityContextStore::list_sandboxes() {
+  auto recordsR = store_.list_by_type(kSandboxIdentityType);
+  if (!recordsR) return referee::Result<std::vector<SandboxIdentityRecord>>::err(recordsR.error.value());
+
+  std::vector<SandboxIdentityRecord> out;
+  out.reserve(recordsR.value->size());
+  for (const auto& rec : recordsR.value.value()) {
+    auto sandboxR = sandbox_record_from_object(rec);
+    if (!sandboxR) {
+      return referee::Result<std::vector<SandboxIdentityRecord>>::err(sandboxR.error.value());
+    }
+    out.push_back(std::move(sandboxR.value.value()));
+  }
+
+  std::sort(out.begin(), out.end(), [](const SandboxIdentityRecord& lhs,
+                                       const SandboxIdentityRecord& rhs) {
+    return lhs.sandbox.id.to_hex() < rhs.sandbox.id.to_hex();
+  });
+  return referee::Result<std::vector<SandboxIdentityRecord>>::ok(std::move(out));
+}
+
+referee::Result<std::vector<SandboxIdentityRecord>>
+CapabilityContextStore::list_sandboxes_for_subject(referee::ObjectID subject) {
+  auto sandboxesR = list_sandboxes();
+  if (!sandboxesR) return sandboxesR;
+
+  std::vector<SandboxIdentityRecord> out;
+  for (auto& record : sandboxesR.value.value()) {
+    auto it = std::find(record.sandbox.subjects.begin(),
+                        record.sandbox.subjects.end(),
+                        subject);
+    if (it != record.sandbox.subjects.end()) out.push_back(std::move(record));
+  }
+  return referee::Result<std::vector<SandboxIdentityRecord>>::ok(std::move(out));
+}
 
 referee::Result<CapabilityContextRecord> CapabilityContextStore::persist_context(
     const CapabilityContext& context) {

--- a/src/services/capability_context.h
+++ b/src/services/capability_context.h
@@ -25,11 +25,29 @@ struct CapabilityContextRecord {
   CapabilityContext context{};
 };
 
+struct SandboxIdentity {
+  referee::ObjectID id{};
+  std::string name;
+  std::vector<referee::ObjectID> subjects{};
+};
+
+struct SandboxIdentityRecord {
+  referee::ObjectRef ref{};
+  SandboxIdentity sandbox{};
+};
+
 constexpr referee::TypeID kCapabilityContextType{0x5356434341500001ULL};
+constexpr referee::TypeID kSandboxIdentityType{0x53564353414E0001ULL};
 
 class CapabilityContextStore {
 public:
   explicit CapabilityContextStore(referee::SqliteStore& store);
+
+  referee::Result<SandboxIdentityRecord> persist_sandbox(const SandboxIdentity& sandbox);
+  referee::Result<std::optional<SandboxIdentityRecord>> get_sandbox(referee::ObjectID id);
+  referee::Result<std::vector<SandboxIdentityRecord>> list_sandboxes();
+  referee::Result<std::vector<SandboxIdentityRecord>> list_sandboxes_for_subject(
+      referee::ObjectID subject);
 
   referee::Result<CapabilityContextRecord> persist_context(const CapabilityContext& context);
   referee::Result<std::optional<CapabilityContextRecord>> get_context(referee::ObjectID id);

--- a/src/services/service.cc
+++ b/src/services/service.cc
@@ -68,6 +68,7 @@ MessageEnvelope make_response(const MessageEnvelope& request,
   MessageEnvelope env;
   env.sender = responder;
   env.recipient = request.sender;
+  env.sandbox = request.sandbox;
   env.message_type = message_type;
   env.payload_cbor = std::move(payload_cbor);
   env.correlation_id = request.correlation_id;

--- a/src/services/service.h
+++ b/src/services/service.h
@@ -24,6 +24,7 @@ struct MessageEnvelope {
   referee::ObjectID sender{};
   std::optional<referee::ObjectID> recipient{};
   std::optional<Endpoint> endpoint{};
+  std::optional<referee::ObjectID> sandbox{};
   referee::TypeID message_type{};
   referee::Bytes payload_cbor{};
   referee::ObjectID correlation_id{};

--- a/tests/test_capability_context.cc
+++ b/tests/test_capability_context.cc
@@ -134,12 +134,109 @@ START_TEST(test_capability_context_rejects_invalid_grants)
 }
 END_TEST
 
+START_TEST(test_sandbox_identity_roundtrip_and_subject_lookup)
+{
+  std::string db_path = make_temp_db_path();
+  ObjectID sandbox_id = ObjectID::random();
+  ObjectID subject_a = ObjectID::random();
+  ObjectID subject_b = ObjectID::random();
+
+  {
+    SqliteStore store(SqliteConfig{ .filename=db_path, .enable_wal=true });
+    ck_assert_msg(store.open(), "open failed");
+    ck_assert_msg(store.ensure_schema(), "ensure_schema failed");
+
+    SandboxIdentity sandbox;
+    sandbox.id = sandbox_id;
+    sandbox.name = "service-host-sandbox";
+    sandbox.subjects.push_back(subject_b);
+    sandbox.subjects.push_back(subject_a);
+
+    CapabilityContextStore contexts(store);
+    auto savedR = contexts.persist_sandbox(sandbox);
+    ck_assert_msg(savedR, "persist_sandbox failed: %s", result_message(savedR));
+    ck_assert(savedR.value->sandbox.id == sandbox_id);
+    ck_assert_str_eq(savedR.value->sandbox.name.c_str(), "service-host-sandbox");
+    ck_assert_uint_eq((unsigned int)savedR.value->sandbox.subjects.size(), 2U);
+    ck_assert_msg(savedR.value->sandbox.subjects[0].to_hex() <
+                  savedR.value->sandbox.subjects[1].to_hex(),
+                  "expected deterministic subject ordering");
+    ck_assert_msg((savedR.value->sandbox.subjects[0] == subject_a ||
+                   savedR.value->sandbox.subjects[1] == subject_a),
+                  "expected subject_a in sandbox subjects");
+    ck_assert_msg((savedR.value->sandbox.subjects[0] == subject_b ||
+                   savedR.value->sandbox.subjects[1] == subject_b),
+                  "expected subject_b in sandbox subjects");
+
+    ck_assert_msg(store.close(), "close failed");
+  }
+
+  {
+    SqliteStore store(SqliteConfig{ .filename=db_path, .enable_wal=true });
+    ck_assert_msg(store.open(), "open failed");
+    ck_assert_msg(store.ensure_schema(), "ensure_schema failed");
+
+    CapabilityContextStore contexts(store);
+    auto loadedR = contexts.get_sandbox(sandbox_id);
+    ck_assert_msg(loadedR, "get_sandbox failed: %s", result_message(loadedR));
+    ck_assert_msg(loadedR.value->has_value(), "expected persisted sandbox identity");
+    ck_assert_str_eq(loadedR.value->value().sandbox.name.c_str(), "service-host-sandbox");
+
+    auto by_subjectR = contexts.list_sandboxes_for_subject(subject_a);
+    ck_assert_msg(by_subjectR, "list_sandboxes_for_subject failed: %s", result_message(by_subjectR));
+    ck_assert_uint_eq((unsigned int)by_subjectR.value->size(), 1U);
+    ck_assert(by_subjectR.value->front().sandbox.id == sandbox_id);
+
+    auto other_subjectR = contexts.list_sandboxes_for_subject(ObjectID::random());
+    ck_assert_msg(other_subjectR, "other subject lookup failed: %s", result_message(other_subjectR));
+    ck_assert_msg(other_subjectR.value->empty(), "expected no sandboxes for other subject");
+
+    ck_assert_msg(store.close(), "close failed");
+  }
+
+  cleanup_db_files(db_path);
+}
+END_TEST
+
+START_TEST(test_sandbox_identity_rejects_invalid_metadata)
+{
+  SqliteStore store(SqliteConfig{ .filename=":memory:", .enable_wal=false });
+  ck_assert_msg(store.open(), "open failed");
+  ck_assert_msg(store.ensure_schema(), "ensure_schema failed");
+
+  CapabilityContextStore contexts(store);
+  SandboxIdentity empty_name;
+  empty_name.id = ObjectID::random();
+
+  auto emptyR = contexts.persist_sandbox(empty_name);
+  ck_assert_msg(!emptyR, "expected empty sandbox name to fail");
+  ck_assert_msg(emptyR.error.has_value(), "expected error details");
+  ck_assert_int_eq((int)emptyR.error->code, (int)ErrorCode::InvalidArgument);
+
+  SandboxIdentity duplicate;
+  duplicate.id = ObjectID::random();
+  duplicate.name = "duplicate-subjects";
+  auto subject = ObjectID::random();
+  duplicate.subjects.push_back(subject);
+  duplicate.subjects.push_back(subject);
+
+  auto duplicateR = contexts.persist_sandbox(duplicate);
+  ck_assert_msg(!duplicateR, "expected duplicate sandbox subject to fail");
+  ck_assert_msg(duplicateR.error.has_value(), "expected error details");
+  ck_assert_int_eq((int)duplicateR.error->code, (int)ErrorCode::InvalidArgument);
+
+  ck_assert_msg(store.close(), "close failed");
+}
+END_TEST
+
 Suite* capability_context_suite(void) {
   Suite* s = suite_create("CapabilityContext");
   TCase* tc = tcase_create("core");
 
   tcase_add_test(tc, test_capability_context_roundtrip_and_subject_lookup);
   tcase_add_test(tc, test_capability_context_rejects_invalid_grants);
+  tcase_add_test(tc, test_sandbox_identity_roundtrip_and_subject_lookup);
+  tcase_add_test(tc, test_sandbox_identity_rejects_invalid_metadata);
 
   suite_add_tcase(s, tc);
   return s;

--- a/tests/test_service_ipc.cc
+++ b/tests/test_service_ipc.cc
@@ -123,6 +123,28 @@ START_TEST(test_ipc_send_receive_ack_and_timeout)
 }
 END_TEST
 
+START_TEST(test_ipc_preserves_sandbox_identity_hook)
+{
+  ServiceRegistry registry;
+  EchoService svc(ObjectID::random(), TypeID{0x9005ULL}, "sandbox-service");
+  ck_assert_msg(registry.register_service(svc.descriptor(), &svc), "register_service failed");
+
+  IpcService ipc(registry);
+  Endpoint endpoint;
+  endpoint.name = "sandbox-service";
+
+  auto sandbox_id = ObjectID::random();
+  auto request = make_request_to_endpoint(ObjectID::random(), endpoint, TypeID{0xBEEF0004ULL}, {});
+  request.sandbox = sandbox_id;
+
+  auto response = ipc.send_request(request, std::chrono::milliseconds(5));
+  ck_assert_msg(response, "send_request failed: %s", result_message(response));
+  ck_assert_msg(response.value.has_value(), "expected response envelope");
+  ck_assert_msg(response.value->sandbox.has_value(), "expected sandbox identity on response");
+  ck_assert(response.value->sandbox.value() == sandbox_id);
+}
+END_TEST
+
 START_TEST(test_ipc_enforces_descriptor_required_grants)
 {
   SqliteStore store(SqliteConfig{ .filename=":memory:", .enable_wal=false });
@@ -207,6 +229,7 @@ Suite* service_ipc_suite(void) {
 
   tcase_add_test(tc, test_service_registry_register_resolve_unregister);
   tcase_add_test(tc, test_ipc_send_receive_ack_and_timeout);
+  tcase_add_test(tc, test_ipc_preserves_sandbox_identity_hook);
   tcase_add_test(tc, test_ipc_enforces_descriptor_required_grants);
   tcase_add_test(tc, test_ipc_enforces_endpoint_required_grants_for_declared_endpoint);
 


### PR DESCRIPTION
## Summary
- add ER-0061 documentation and status entry
- add persisted sandbox identity metadata to the capability context store
- add subject lookup and invalid-metadata checks for sandbox identities
- add optional sandbox identity metadata to service IPC envelopes
- preserve sandbox identity through request/response helpers without enforcing isolation

## Validation
- make -C tests check TESTS="test_capability_context test_service_ipc"
- make check

## Notes
- ER-0061 is metadata/hooks only by direction; sandbox enforcement remains out of scope
- no Autotools regeneration was needed