### PR TITLE
feat: add ER-0062 memory service baseline

### DIFF
--- a/docs/ER/ER-0062-Memory-Service-Baseline.md
+++ b/docs/ER/ER-0062-Memory-Service-Baseline.md
@@ -1,0 +1,101 @@
+---
+GitHub-Issue: N/A
+---
+
+# ER-0062 — Memory Service Baseline
+
+## Roles
+
+- Implementation Engineer: drafts and implements changes
+- System Engineer: reviews, tests, and verifies
+- Note: Only the System Engineer may mark an ER as Verified.
+
+## ER Metadata
+
+- ER ID: ER-0062
+- Title: Memory Service Baseline
+- Status: Complete
+- Date: 2026-05-26
+- Owners: Mike
+- Type: Enhancement
+
+## Engineering Guidelines
+
+- Implementation language baseline: C++20 or C++24.
+- Avoid line compaction or formatting changes that risk obscuring or losing content.
+- Keep source files reasonably small. If a file grows too large to be fully replaced in a change, split it into smaller local files.
+
+## Context
+
+- Problem statement: AR-0022 Stage E calls for expanded core services after service identity, persistence, capability context, and sandbox hooks are established. Network services are too broad for the first Stage E slice, but the system needs a smaller core service that can model memory resources.
+- Background / constraints: ER-0057 through ER-0061 established the local service substrate, registry behavior, capability context, boundary checks, and sandbox identity hooks. This ER intentionally keeps memory service behavior metadata-oriented and does not expose raw memory access.
+
+## Goals
+
+- Introduce a first Stage E Memory Service.
+- Model baseline memory regions as RAM, flash, or read-only regions.
+- Provide local service endpoints for registering, listing, and looking up memory regions.
+- Expose deterministic mutability metadata for region kinds.
+
+## Non-Goals
+
+- Network service implementation.
+- Object-system or Referee-access service implementation.
+- Inner processor, register, or stack service implementation.
+- Allocation, paging, virtual memory, MMIO, DMA, or raw memory read/write behavior.
+- Real hardware discovery.
+
+## Scope
+
+- In scope: in-process Memory Service object.
+- In scope: memory region metadata with ID, name, kind, base, and size.
+- In scope: local IPC endpoints for register, list, and lookup.
+- In scope: duplicate and invalid region rejection.
+- Out of scope: persistence of memory regions through Referee.
+- Out of scope: hardware-backed or sandbox-enforced memory access.
+
+## Requirements
+
+- Functional: callers can register RAM, flash, and read-only memory region metadata.
+- Functional: callers can list registered memory regions through the service endpoint.
+- Functional: callers can look up a region by ID through the service endpoint.
+- Functional: duplicate region IDs and duplicate region names are rejected.
+- Functional: empty names and zero-sized regions are rejected.
+- Non-functional: the service remains local, deterministic, and testable through existing Service Plane IPC.
+
+## Proposed Approach
+
+- Summary: add a `MemoryService` implementation under the existing service subsystem and represent region registration/list/lookup requests as CBOR-encoded JSON payloads.
+- Alternatives considered: a broader Stage E catalog covering memory, object-system, and inner processor services was deferred because each service has distinct policy and safety questions. A network service was deferred as too much scope for this first Stage E implementation.
+
+## Acceptance Criteria
+
+- Tests verify memory region registration through IPC.
+- Tests verify listing registered regions through IPC.
+- Tests verify lookup by region ID through IPC.
+- Tests verify duplicate and invalid region rejection.
+- Tests verify RAM, flash, and read-only mutability classification.
+
+## Risks / Open Questions
+
+- Risk: callers may assume region metadata implies real allocation or hardware access; this ER does not provide either.
+- Question: should memory regions become persisted Referee objects in a follow-on ER?
+- Question: should flash writes require a distinct endpoint and capability grant in a follow-on ER?
+
+## Dependencies
+
+- Dependency 1: AR-0022 Staged Service Plane Delivery.
+- Dependency 2: AR-0005 Service Plane Model.
+- Dependency 3: ER-0061 Sandbox Identity and Service Isolation Hooks.
+
+## Implementation Notes
+
+- Notes for implementer: keep this slice metadata-only.
+- Notes for implementer: do not add allocation or raw read/write semantics until the policy model is explicit.
+
+## Verification Plan
+
+- Tests to run:
+  - `make check`
+- Manual checks:
+  - register RAM, flash, and read-only regions through the memory service, then list and look them up.

--- a/docs/ER/ER-Status.md
+++ b/docs/ER/ER-Status.md
@@ -71,6 +71,7 @@
 - ER-0059 — Complete
 - ER-0060 — Complete
 - ER-0061 — Complete
+- ER-0062 — Complete
 - ER-0078 — Complete
 - ER-0079 — Proposed
 - ER-0080 — Proposed

--- a/src/services/service.cc
+++ b/src/services/service.cc
@@ -3,7 +3,10 @@
 #include "services/capability_context.h"
 
 #include <chrono>
+#include <stdexcept>
 #include <unordered_set>
+
+#include <nlohmann/json.hpp>
 
 namespace iris::service {
 
@@ -29,6 +32,17 @@ static std::optional<Endpoint> find_declared_endpoint(const ServiceDescriptor& s
     if (endpoint_matches(endpoint, requested.value())) return endpoint;
   }
   return std::nullopt;
+}
+
+static std::string endpoint_key(const std::optional<Endpoint>& endpoint) {
+  if (!endpoint.has_value()) return {};
+  if (!endpoint->name.empty()) return endpoint->name;
+  if (endpoint->type.has_value()) {
+    if (endpoint->type.value() == kMemoryRegisterRegionType) return "memory.register_region";
+    if (endpoint->type.value() == kMemoryListRegionsType) return "memory.list_regions";
+    if (endpoint->type.value() == kMemoryLookupRegionType) return "memory.lookup_region";
+  }
+  return {};
 }
 
 MessageEnvelope make_request_to_object(referee::ObjectID sender,
@@ -74,6 +88,184 @@ MessageEnvelope make_response(const MessageEnvelope& request,
   env.correlation_id = request.correlation_id;
   env.timestamp_unix_ms = referee::unix_ms_now();
   return env;
+}
+
+std::string_view memory_region_kind_name(MemoryRegionKind kind) {
+  switch (kind) {
+  case MemoryRegionKind::Ram:
+    return "ram";
+  case MemoryRegionKind::Flash:
+    return "flash";
+  case MemoryRegionKind::ReadOnly:
+    return "read_only";
+  }
+  return "unknown";
+}
+
+bool memory_region_is_writable(MemoryRegionKind kind) {
+  return kind == MemoryRegionKind::Ram || kind == MemoryRegionKind::Flash;
+}
+
+bool memory_region_is_persistent(MemoryRegionKind kind) {
+  return kind == MemoryRegionKind::Flash || kind == MemoryRegionKind::ReadOnly;
+}
+
+static referee::Result<MemoryRegionKind> memory_region_kind_from_name(std::string_view name) {
+  if (name == "ram") return referee::Result<MemoryRegionKind>::ok(MemoryRegionKind::Ram);
+  if (name == "flash") return referee::Result<MemoryRegionKind>::ok(MemoryRegionKind::Flash);
+  if (name == "read_only") return referee::Result<MemoryRegionKind>::ok(MemoryRegionKind::ReadOnly);
+  return referee::Result<MemoryRegionKind>::err(referee::ErrorCode::InvalidArgument,
+                                                "unknown memory region kind");
+}
+
+static nlohmann::json memory_region_to_json(const MemoryRegion& region) {
+  nlohmann::json j;
+  j["id"] = region.id.to_hex();
+  j["name"] = region.name;
+  j["kind"] = std::string(memory_region_kind_name(region.kind));
+  j["base"] = region.base;
+  j["size"] = region.size;
+  j["writable"] = memory_region_is_writable(region.kind);
+  j["persistent"] = memory_region_is_persistent(region.kind);
+  return j;
+}
+
+static referee::Result<MemoryRegion> memory_region_from_json(const nlohmann::json& j) {
+  if (!j.is_object()) {
+    return referee::Result<MemoryRegion>::err(referee::ErrorCode::InvalidArgument,
+                                              "memory region payload must be an object");
+  }
+
+  try {
+    MemoryRegion region;
+    region.id = referee::ObjectID::from_hex(j.at("id").get<std::string>());
+    region.name = j.at("name").get<std::string>();
+    auto kindR = memory_region_kind_from_name(j.at("kind").get<std::string>());
+    if (!kindR) return referee::Result<MemoryRegion>::err(kindR.error.value());
+    region.kind = kindR.value.value();
+    region.base = j.at("base").get<std::uint64_t>();
+    region.size = j.at("size").get<std::uint64_t>();
+    return referee::Result<MemoryRegion>::ok(std::move(region));
+  } catch (const std::exception& ex) {
+    return referee::Result<MemoryRegion>::err(referee::ErrorCode::InvalidArgument, ex.what());
+  }
+}
+
+static referee::Result<nlohmann::json> json_from_cbor_payload(const referee::Bytes& payload) {
+  try {
+    return referee::Result<nlohmann::json>::ok(nlohmann::json::from_cbor(payload));
+  } catch (const std::exception& ex) {
+    return referee::Result<nlohmann::json>::err(referee::ErrorCode::InvalidArgument, ex.what());
+  }
+}
+
+MemoryService::MemoryService(referee::ObjectID id) {
+  desc_.id = id;
+  desc_.type = kMemoryServiceType;
+  desc_.name = "memory";
+  desc_.endpoints.push_back(Endpoint{"memory.register_region", kMemoryRegisterRegionType, {}});
+  desc_.endpoints.push_back(Endpoint{"memory.list_regions", kMemoryListRegionsType, {}});
+  desc_.endpoints.push_back(Endpoint{"memory.lookup_region", kMemoryLookupRegionType, {}});
+}
+
+ServiceDescriptor MemoryService::descriptor() const {
+  return desc_;
+}
+
+referee::Result<MemoryRegion> MemoryService::register_region(const MemoryRegion& region) {
+  if (region.name.empty()) {
+    return referee::Result<MemoryRegion>::err(referee::ErrorCode::InvalidArgument,
+                                              "memory region name is empty");
+  }
+  if (region.size == 0) {
+    return referee::Result<MemoryRegion>::err(referee::ErrorCode::InvalidArgument,
+                                              "memory region size is zero");
+  }
+
+  for (const auto& existing : regions_) {
+    if (existing.id == region.id) {
+      return referee::Result<MemoryRegion>::err(referee::ErrorCode::AlreadyExists,
+                                                "memory region id already registered");
+    }
+    if (existing.name == region.name) {
+      return referee::Result<MemoryRegion>::err(referee::ErrorCode::AlreadyExists,
+                                                "memory region name already registered");
+    }
+  }
+
+  regions_.push_back(region);
+  return referee::Result<MemoryRegion>::ok(region);
+}
+
+referee::Result<std::optional<MemoryRegion>> MemoryService::lookup_region(referee::ObjectID id) const {
+  for (const auto& region : regions_) {
+    if (region.id == id) {
+      return referee::Result<std::optional<MemoryRegion>>::ok(std::optional<MemoryRegion>{region});
+    }
+  }
+  return referee::Result<std::optional<MemoryRegion>>::ok(std::optional<MemoryRegion>{});
+}
+
+std::vector<MemoryRegion> MemoryService::list_regions() const {
+  return regions_;
+}
+
+referee::Result<MessageEnvelope> MemoryService::handle_message(const MessageEnvelope& request) {
+  auto key = endpoint_key(request.endpoint);
+  if (key == "memory.register_region") {
+    auto jsonR = json_from_cbor_payload(request.payload_cbor);
+    if (!jsonR) return referee::Result<MessageEnvelope>::err(jsonR.error.value());
+    auto regionR = memory_region_from_json(jsonR.value.value());
+    if (!regionR) return referee::Result<MessageEnvelope>::err(regionR.error.value());
+    auto registeredR = register_region(regionR.value.value());
+    if (!registeredR) return referee::Result<MessageEnvelope>::err(registeredR.error.value());
+    auto response = make_response(request,
+                                  desc_.id,
+                                  kMemoryRegionResponseType,
+                                  nlohmann::json::to_cbor(memory_region_to_json(registeredR.value.value())));
+    return referee::Result<MessageEnvelope>::ok(std::move(response));
+  }
+
+  if (key == "memory.list_regions") {
+    nlohmann::json root;
+    root["regions"] = nlohmann::json::array();
+    for (const auto& region : regions_) {
+      root["regions"].push_back(memory_region_to_json(region));
+    }
+    auto response = make_response(request,
+                                  desc_.id,
+                                  kMemoryRegionListResponseType,
+                                  nlohmann::json::to_cbor(root));
+    return referee::Result<MessageEnvelope>::ok(std::move(response));
+  }
+
+  if (key == "memory.lookup_region") {
+    auto jsonR = json_from_cbor_payload(request.payload_cbor);
+    if (!jsonR) return referee::Result<MessageEnvelope>::err(jsonR.error.value());
+
+    try {
+      auto id = referee::ObjectID::from_hex(jsonR.value->at("id").get<std::string>());
+      auto foundR = lookup_region(id);
+      if (!foundR) return referee::Result<MessageEnvelope>::err(foundR.error.value());
+
+      nlohmann::json root;
+      root["found"] = foundR.value->has_value();
+      if (foundR.value->has_value()) {
+        root["region"] = memory_region_to_json(foundR.value->value());
+      }
+
+      auto response = make_response(request,
+                                    desc_.id,
+                                    kMemoryRegionResponseType,
+                                    nlohmann::json::to_cbor(root));
+      return referee::Result<MessageEnvelope>::ok(std::move(response));
+    } catch (const std::exception& ex) {
+      return referee::Result<MessageEnvelope>::err(referee::ErrorCode::InvalidArgument, ex.what());
+    }
+  }
+
+  return referee::Result<MessageEnvelope>::err(referee::ErrorCode::InvalidArgument,
+                                               "unsupported memory service endpoint");
 }
 
 referee::Result<void> ServiceRegistry::register_service(const ServiceDescriptor& desc,

--- a/src/services/service.h
+++ b/src/services/service.h
@@ -125,4 +125,45 @@ private:
   ServiceBoundaryAuthorizer* authorizer_{nullptr};
 };
 
+enum class MemoryRegionKind {
+  Ram,
+  Flash,
+  ReadOnly,
+};
+
+struct MemoryRegion {
+  referee::ObjectID id{};
+  std::string name;
+  MemoryRegionKind kind{MemoryRegionKind::Ram};
+  std::uint64_t base{};
+  std::uint64_t size{};
+};
+
+constexpr referee::TypeID kMemoryServiceType{0x5356434D454D0001ULL};
+constexpr referee::TypeID kMemoryRegisterRegionType{0x5356434D454D1001ULL};
+constexpr referee::TypeID kMemoryListRegionsType{0x5356434D454D1002ULL};
+constexpr referee::TypeID kMemoryLookupRegionType{0x5356434D454D1003ULL};
+constexpr referee::TypeID kMemoryRegionResponseType{0x5356434D454D2001ULL};
+constexpr referee::TypeID kMemoryRegionListResponseType{0x5356434D454D2002ULL};
+
+std::string_view memory_region_kind_name(MemoryRegionKind kind);
+bool memory_region_is_writable(MemoryRegionKind kind);
+bool memory_region_is_persistent(MemoryRegionKind kind);
+
+class MemoryService final : public ServiceObject {
+public:
+  explicit MemoryService(referee::ObjectID id);
+
+  ServiceDescriptor descriptor() const override;
+  referee::Result<MessageEnvelope> handle_message(const MessageEnvelope& request) override;
+
+  referee::Result<MemoryRegion> register_region(const MemoryRegion& region);
+  referee::Result<std::optional<MemoryRegion>> lookup_region(referee::ObjectID id) const;
+  std::vector<MemoryRegion> list_regions() const;
+
+private:
+  ServiceDescriptor desc_{};
+  std::vector<MemoryRegion> regions_;
+};
+
 } // namespace iris::service

--- a/tests/test_service_ipc.cc
+++ b/tests/test_service_ipc.cc
@@ -14,6 +14,8 @@ extern "C" {
 #include <utility>
 #include <vector>
 
+#include <nlohmann/json.hpp>
+
 using namespace referee;
 using namespace iris::service;
 
@@ -223,6 +225,143 @@ START_TEST(test_ipc_enforces_endpoint_required_grants_for_declared_endpoint)
 }
 END_TEST
 
+START_TEST(test_memory_service_registers_and_lists_regions)
+{
+  ServiceRegistry registry;
+  MemoryService memory(ObjectID::random());
+  ck_assert_msg(registry.register_service(memory.descriptor(), &memory), "register_service failed");
+
+  IpcService ipc(registry);
+  auto region_id = ObjectID::random();
+
+  nlohmann::json payload;
+  payload["id"] = region_id.to_hex();
+  payload["name"] = "main-ram";
+  payload["kind"] = "ram";
+  payload["base"] = 4096ULL;
+  payload["size"] = 8192ULL;
+
+  auto request = make_request_to_object(ObjectID::random(),
+                                        memory.descriptor().id,
+                                        kMemoryRegisterRegionType,
+                                        nlohmann::json::to_cbor(payload));
+  request.endpoint = Endpoint{"memory.register_region", kMemoryRegisterRegionType, {}};
+
+  auto response = ipc.send_request(request, std::chrono::milliseconds(5));
+  ck_assert_msg(response, "register region failed: %s", result_message(response));
+  ck_assert_uint_eq(response.value->message_type.v, kMemoryRegionResponseType.v);
+
+  auto registered = nlohmann::json::from_cbor(response.value->payload_cbor);
+  ck_assert_str_eq(registered.at("name").get<std::string>().c_str(), "main-ram");
+  ck_assert_str_eq(registered.at("kind").get<std::string>().c_str(), "ram");
+  ck_assert(registered.at("writable").get<bool>());
+  ck_assert(!registered.at("persistent").get<bool>());
+
+  auto list_request = make_request_to_object(ObjectID::random(),
+                                             memory.descriptor().id,
+                                             kMemoryListRegionsType,
+                                             {});
+  list_request.endpoint = Endpoint{"memory.list_regions", kMemoryListRegionsType, {}};
+
+  auto list_response = ipc.send_request(list_request, std::chrono::milliseconds(5));
+  ck_assert_msg(list_response, "list regions failed: %s", result_message(list_response));
+  ck_assert_uint_eq(list_response.value->message_type.v, kMemoryRegionListResponseType.v);
+
+  auto list_payload = nlohmann::json::from_cbor(list_response.value->payload_cbor);
+  ck_assert_uint_eq(list_payload.at("regions").size(), 1);
+  ck_assert_str_eq(list_payload.at("regions").at(0).at("id").get<std::string>().c_str(),
+                   region_id.to_hex().c_str());
+}
+END_TEST
+
+START_TEST(test_memory_service_rejects_duplicates_and_invalid_regions)
+{
+  MemoryService memory(ObjectID::random());
+  MemoryRegion ram;
+  ram.id = ObjectID::random();
+  ram.name = "main-ram";
+  ram.kind = MemoryRegionKind::Ram;
+  ram.base = 0;
+  ram.size = 4096;
+
+  auto registered = memory.register_region(ram);
+  ck_assert_msg(registered, "register_region failed: %s", result_message(registered));
+
+  auto duplicate_id = memory.register_region(ram);
+  ck_assert_msg(!duplicate_id, "expected duplicate id rejection");
+  ck_assert_int_eq((int)duplicate_id.error->code, (int)ErrorCode::AlreadyExists);
+
+  MemoryRegion duplicate_name = ram;
+  duplicate_name.id = ObjectID::random();
+  auto duplicate_nameR = memory.register_region(duplicate_name);
+  ck_assert_msg(!duplicate_nameR, "expected duplicate name rejection");
+  ck_assert_int_eq((int)duplicate_nameR.error->code, (int)ErrorCode::AlreadyExists);
+
+  MemoryRegion empty_name = ram;
+  empty_name.id = ObjectID::random();
+  empty_name.name.clear();
+  auto empty_nameR = memory.register_region(empty_name);
+  ck_assert_msg(!empty_nameR, "expected empty name rejection");
+  ck_assert_int_eq((int)empty_nameR.error->code, (int)ErrorCode::InvalidArgument);
+
+  MemoryRegion empty_region = ram;
+  empty_region.id = ObjectID::random();
+  empty_region.name = "empty";
+  empty_region.size = 0;
+  auto empty_regionR = memory.register_region(empty_region);
+  ck_assert_msg(!empty_regionR, "expected zero-size rejection");
+  ck_assert_int_eq((int)empty_regionR.error->code, (int)ErrorCode::InvalidArgument);
+}
+END_TEST
+
+START_TEST(test_memory_service_lookup_and_mutability_classification)
+{
+  ServiceRegistry registry;
+  MemoryService memory(ObjectID::random());
+  ck_assert_msg(registry.register_service(memory.descriptor(), &memory), "register_service failed");
+
+  MemoryRegion flash;
+  flash.id = ObjectID::random();
+  flash.name = "boot-flash";
+  flash.kind = MemoryRegionKind::Flash;
+  flash.base = 65536;
+  flash.size = 4096;
+  ck_assert_msg(memory.register_region(flash), "flash register failed");
+
+  MemoryRegion readonly;
+  readonly.id = ObjectID::random();
+  readonly.name = "rom";
+  readonly.kind = MemoryRegionKind::ReadOnly;
+  readonly.base = 131072;
+  readonly.size = 4096;
+  ck_assert_msg(memory.register_region(readonly), "readonly register failed");
+
+  ck_assert(memory_region_is_writable(MemoryRegionKind::Flash));
+  ck_assert(memory_region_is_persistent(MemoryRegionKind::Flash));
+  ck_assert(!memory_region_is_writable(MemoryRegionKind::ReadOnly));
+  ck_assert(memory_region_is_persistent(MemoryRegionKind::ReadOnly));
+
+  IpcService ipc(registry);
+  nlohmann::json payload;
+  payload["id"] = readonly.id.to_hex();
+
+  auto request = make_request_to_object(ObjectID::random(),
+                                        memory.descriptor().id,
+                                        kMemoryLookupRegionType,
+                                        nlohmann::json::to_cbor(payload));
+  request.endpoint = Endpoint{"memory.lookup_region", kMemoryLookupRegionType, {}};
+
+  auto response = ipc.send_request(request, std::chrono::milliseconds(5));
+  ck_assert_msg(response, "lookup region failed: %s", result_message(response));
+
+  auto lookup_payload = nlohmann::json::from_cbor(response.value->payload_cbor);
+  ck_assert(lookup_payload.at("found").get<bool>());
+  ck_assert_str_eq(lookup_payload.at("region").at("kind").get<std::string>().c_str(), "read_only");
+  ck_assert(!lookup_payload.at("region").at("writable").get<bool>());
+  ck_assert(lookup_payload.at("region").at("persistent").get<bool>());
+}
+END_TEST
+
 Suite* service_ipc_suite(void) {
   Suite* s = suite_create("ServiceIPC");
   TCase* tc = tcase_create("core");
@@ -232,6 +371,9 @@ Suite* service_ipc_suite(void) {
   tcase_add_test(tc, test_ipc_preserves_sandbox_identity_hook);
   tcase_add_test(tc, test_ipc_enforces_descriptor_required_grants);
   tcase_add_test(tc, test_ipc_enforces_endpoint_required_grants_for_declared_endpoint);
+  tcase_add_test(tc, test_memory_service_registers_and_lists_regions);
+  tcase_add_test(tc, test_memory_service_rejects_duplicates_and_invalid_regions);
+  tcase_add_test(tc, test_memory_service_lookup_and_mutability_classification);
 
   suite_add_tcase(s, tc);
   return s;


### PR DESCRIPTION
## Summary

- Adds ER-0062 as the Stage E Memory Service baseline.
- Introduces `MemoryService` with RAM, flash, and read-only region metadata.
- Adds local IPC endpoints for register, list, and lookup.
- Adds tests for IPC dispatch, duplicate/invalid rejection, lookup, and mutability classification.
- Updates the ER status ledger to mark ER-0062 Complete.

## Files touched

- `docs/ER/ER-0062-Memory-Service-Baseline.md`
- `docs/ER/ER-Status.md`
- `src/services/service.h`
- `src/services/service.cc`
- `tests/test_service_ipc.cc`

## Validation

- `make check`
- Result: 22 passed, 0 failed.

## Assumptions / caveats

- This ER is metadata-only: no allocation, paging, raw memory read/write, MMIO, DMA, real hardware discovery, or persistence.
- Flash is classified as writable and persistent; read-only is persistent and not writable.
- Object-system and inner-processor services are intentionally left for follow-on ERs.

## Autotools

- No Autotools inputs were changed.
- No generated files were regenerated.
