### PR TITLE
docs: sync AR-0022 through AR-0026 issues

### DIFF
--- a/docs/AR/accepted/AR-0022-Staged-Service-Plane-Delivery.md
+++ b/docs/AR/accepted/AR-0022-Staged-Service-Plane-Delivery.md
@@ -1,5 +1,5 @@
 ---
-GitHub-Issue: N/A
+GitHub-Issue: #290
 ER-Dependencies: ER-0057
 ---
 

--- a/docs/AR/accepted/AR-0023-Refract-Reflection-Profiles.md
+++ b/docs/AR/accepted/AR-0023-Refract-Reflection-Profiles.md
@@ -1,5 +1,5 @@
 ---
-GitHub-Issue: N/A
+GitHub-Issue: #291
 ER-Dependencies: ER-0055, ER-0078, ER-0079, ER-0080
 ---
 

--- a/docs/AR/accepted/AR-0024-Erector-Machine-and-Comms-Delivery-Tracks.md
+++ b/docs/AR/accepted/AR-0024-Erector-Machine-and-Comms-Delivery-Tracks.md
@@ -1,5 +1,5 @@
 ---
-GitHub-Issue: N/A
+GitHub-Issue: #292
 ER-Dependencies: ER-0015, ER-0016, ER-0017, ER-0045, ER-0045.1, ER-0045.2, ER-0045.3, ER-0045.4
 ---
 

--- a/docs/AR/accepted/AR-0025-Conch-and-Vizier-Interaction-Modes.md
+++ b/docs/AR/accepted/AR-0025-Conch-and-Vizier-Interaction-Modes.md
@@ -1,5 +1,5 @@
 ---
-GitHub-Issue: N/A
+GitHub-Issue: #293
 ER-Dependencies: ER-0008, ER-0009, ER-0010, ER-0011, ER-0052, ER-0054
 ---
 

--- a/docs/AR/accepted/AR-0026-Conch-Parser-Maturity-Levels.md
+++ b/docs/AR/accepted/AR-0026-Conch-Parser-Maturity-Levels.md
@@ -1,5 +1,5 @@
 ---
-GitHub-Issue: N/A
+GitHub-Issue: #294
 ER-Dependencies: ER-0056
 ---
 


### PR DESCRIPTION
## Summary
- created GitHub issues for AR-0022 through AR-0026 using scripts/issue_sync.sh
- updated each AR document's GitHub-Issue front matter to the assigned issue number
- issues #290 through #294 remain open with ar/status:accepted labels

## Validation
- scripts/issue_sync.sh docs/AR/accepted/AR-0022-Staged-Service-Plane-Delivery.md
- scripts/issue_sync.sh docs/AR/accepted/AR-0023-Refract-Reflection-Profiles.md
- scripts/issue_sync.sh docs/AR/accepted/AR-0024-Erector-Machine-and-Comms-Delivery-Tracks.md
- scripts/issue_sync.sh docs/AR/accepted/AR-0025-Conch-and-Vizier-Interaction-Modes.md
- scripts/issue_sync.sh docs/AR/accepted/AR-0026-Conch-Parser-Maturity-Levels.md
- git diff --check
- gh issue list --state all --limit 15 --json number,title,state,labels --search "repo:justgus/IrisOS label:ar"

## Caveat
- The AR-0023 sync command returned nonzero after creating/updating issue #291 because the script exits during AR dependency closure checks when it sees unverified dependent ERs. The resulting issue state and document link were verified manually.