### PR TITLE
docs: seed Agile Airframe migration sprint

### DIFF
--- a/.airframe/airframe-workspace.json
+++ b/.airframe/airframe-workspace.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "workspace": {
+    "id": { "rawValue": "WS-IRISOS" },
+    "name": "IrisOS Airframe Workspace",
+    "rootPath": "."
+  },
+  "projects": [
+    {
+      "id": { "rawValue": "PRJ-IRISOS" },
+      "name": "IrisOS",
+      "repository": "justgus/IrisOS",
+      "activeSprintID": { "rawValue": "SP-001" },
+      "activeEpicID": { "rawValue": "EP-001" }
+    }
+  ],
+  "defaultProjectID": { "rawValue": "PRJ-IRISOS" },
+  "backend": {
+    "kind": "github-issues",
+    "location": "justgus/IrisOS"
+  }
+}

--- a/docs/Epics/Epic-Documentation.md
+++ b/docs/Epics/Epic-Documentation.md
@@ -1,0 +1,45 @@
+# Epics - Index
+
+This is the main index for IrisOS Agile Airframe Epics. Epics describe delivery outcomes and do not replace IrisOS architecture records.
+
+> **Related:** [Tasks](../Tasks/Task-Documentation.md) | [Issues](../Issues/Issue-Documentation.md) | [Sprints](../Sprints/Sprint-Documentation.md)
+
+## Organization
+
+- **Epic-backlog.md** - Proposed Epics queued for future planning.
+- **Epic-active.md** - Epics that are Draft, Active, or Complete pending closeout.
+- **Closed/** - Archived closed Epics.
+
+## Active Epics
+
+Currently: **1 Active Epic**
+
+See: [Epic-active.md](Epic-active.md)
+
+## Backlog Epics
+
+Currently: **0 Backlog Epics**
+
+See: [Epic-backlog.md](Epic-backlog.md)
+
+## All Epics
+
+Currently: **1 Epic** | Next available: **EP-002**
+
+| Epic | Title | Status | Start | Close |
+| ---- | ----- | ------ | ----- | ----- |
+| EP-001 | Migrate IrisOS Workflow Documentation to Agile Airframe | Active | 2026-07-06 | TBD |
+
+## Statistics
+
+- **Total Epics:** 1
+- **Closed:** 0
+- **Active:** 1
+- **Complete:** 0
+- **Draft:** 0
+- **Proposed:** 0
+- **Next available:** EP-002
+
+---
+
+*Last Updated: 2026-07-06 (EP-001 created for Agile Airframe migration planning)*

--- a/docs/Epics/Epic-active.md
+++ b/docs/Epics/Epic-active.md
@@ -1,0 +1,78 @@
+# Epic Active
+
+Epics listed here are drafted, active, or complete-pending-close and are the current focus of planning or execution.
+
+---
+
+## EP-001: Migrate IrisOS Workflow Documentation to Agile Airframe
+
+**Status:** Active
+**Owner:** System Engineer
+**Start Date:** 2026-07-06
+**Target Close Date:** TBD
+**Close Date:** TBD
+
+**Goal:**
+Move IrisOS from the manually maintained AR/ER/DR workflow into the Agile Airframe canonical workflow structure while preserving the current manual documentation state.
+
+**Rationale:**
+IrisOS currently tracks architecture recommendations, engineering requests, defect reports, and GitHub issue state through manually maintained documents. Agile Airframe provides a canonical workflow structure for Epics, Sprints, Tasks, Issues, GitHub mapping, and deterministic status projection. The migration must preserve existing IrisOS state without converting ARs into delivery Epics and without inventing historical Sprint records.
+
+**Scope:**
+- Add IrisOS Agile Airframe workspace configuration.
+- Add canonical Airframe planning folders and indexes.
+- Preserve ARs as separate architecture records.
+- Migrate ERs into Airframe Tasks using Task numbers extended from the current ER list.
+- Migrate DRs into Airframe Issues.
+- Preserve GitHub issue references and document any local/GitHub state drift before mutation.
+- Start Airframe Sprint tracking with SP-001 only; do not construct Sprint history.
+- Provide local validation and review evidence for the migration.
+
+**Out of Scope:**
+- Reclassifying ARs as Epics.
+- Reconstructing historical Sprints from existing implementation plans.
+- Marking any ER, Task, DR, or Issue verified without System Engineer approval.
+- Mutating GitHub issues, labels, titles, or bodies before a reviewed migration map is approved.
+- Changing product behavior or C++ source code.
+
+**Acceptance Criteria:**
+1. IrisOS has a repo-local Airframe workspace configuration for `justgus/IrisOS`.
+2. Airframe Epics, Sprints, Tasks, and Issues indexes exist and identify current active work.
+3. ARs remain separate architecture records and are not converted into Epics.
+4. SP-001 exists as the first Airframe Sprint and no historical Sprint archive is invented.
+5. ER-derived Tasks preserve original ER IDs, titles, statuses, GitHub issue references, dependencies, and verification details.
+6. DR-derived Issues preserve original DR IDs, titles, statuses, GitHub issue references, severity, reproduction, fix, and verification details.
+7. A migration audit identifies all local/GitHub status mismatches before any GitHub mutation.
+8. Generated or migrated indexes preserve the same canonical state as the current manual documentation.
+9. GitHub issue migration steps are documented and require explicit approval before execution.
+10. Validation commands and results are recorded before the migration is proposed for closeout.
+
+### Related Sprints
+
+| Sprint | Goal | Status |
+| ------ | ---- | ------ |
+| SP-001 | Plan and implement the Agile Airframe documentation migration seed, audit, canonical conversion, GitHub mapping plan, and cutover validation. | Active |
+
+### Related Tasks
+
+| Task | Title | Status |
+| ---- | ----- | ------ |
+| T-0081 | Audit current AR/ER/DR documentation and GitHub issue state | Active |
+| T-0082 | Install IrisOS Airframe workspace configuration and canonical planning structure | Active |
+| T-0083 | Define separate architecture-record handling for ARs | Active |
+| T-0084 | Migrate ER records into Airframe Tasks | Active |
+| T-0085 | Migrate DR records into Airframe Issues | Active |
+| T-0086 | Generate Airframe indexes and GitHub issue mapping | Active |
+| T-0087 | Prepare approved GitHub issue synchronization migration | Active |
+| T-0088 | Validate migration equivalence and document cutover | Active |
+
+### Related Issues
+
+| Issue | Title | Status |
+| ----- | ----- | ------ |
+
+### Notes
+
+Task IDs begin at T-0081 to extend from the current highest IrisOS ER ID, ER-0080. GitHub issue fields remain TBD until the GitHub mutation plan is reviewed and approved.
+
+*Last Updated: 2026-07-06*

--- a/docs/Epics/Epic-backlog.md
+++ b/docs/Epics/Epic-backlog.md
@@ -1,0 +1,9 @@
+# Epic Backlog
+
+Epics listed here are proposed and not currently active.
+
+Currently: **0 backlog Epics**
+
+---
+
+*Last Updated: 2026-07-06*

--- a/docs/Issues/Issue-Documentation.md
+++ b/docs/Issues/Issue-Documentation.md
@@ -1,0 +1,47 @@
+# Issues - Index
+
+This is the main index for IrisOS Agile Airframe Issues. Issues track bugs, regressions, and unintended system behavior.
+
+> **Note:** For planned improvements, use [Tasks](../Tasks/Task-Documentation.md).
+> **Related:** [Epics](../Epics/Epic-Documentation.md) | [Sprints](../Sprints/Sprint-Documentation.md)
+
+## Organization
+
+- **Issue-backlog.md** - Open Issues not assigned to a Sprint.
+- **Issue-active.md** - Active unresolved Issues assigned to a Sprint.
+- **Verified/** - Resolved and System Engineer verified Issues.
+- **Closed/** - Issues closed without verification by System Engineer direction.
+
+## Active Issues
+
+Currently: **0 active Issues**
+
+See: [Issue-active.md](Issue-active.md)
+
+## Backlogged Issues
+
+Currently: **0 backlogged Issues**
+
+See: [Issue-backlog.md](Issue-backlog.md)
+
+## Verified Issues
+
+Currently: **0 verified Issues** | Next available: **I-0001**
+
+## Closed Issues
+
+Currently: **0 closed Issues**
+
+## Statistics
+
+- **Total Issues:** 0
+- **Backlogged:** 0
+- **Active/In Progress:** 0
+- **Resolved - Not Verified:** 0
+- **Verified:** 0
+- **Closed:** 0
+- **Next available:** I-0001
+
+---
+
+*Last Updated: 2026-07-06 (Issue structure created; DR migration not yet performed)*

--- a/docs/Issues/Issue-active.md
+++ b/docs/Issues/Issue-active.md
@@ -1,0 +1,9 @@
+# Active Issues
+
+Issues listed here are assigned to a Sprint and actively being investigated or fixed.
+
+Currently: **0 active Issues**
+
+---
+
+*Last Updated: 2026-07-06*

--- a/docs/Issues/Issue-backlog.md
+++ b/docs/Issues/Issue-backlog.md
@@ -1,0 +1,9 @@
+# Issue Backlog
+
+Issues listed here are open and not assigned to an active Sprint.
+
+Currently: **0 backlog Issues**
+
+---
+
+*Last Updated: 2026-07-06*

--- a/docs/Sprints/Sprint-Documentation.md
+++ b/docs/Sprints/Sprint-Documentation.md
@@ -1,0 +1,38 @@
+# Sprints - Index
+
+This is the main index for IrisOS Agile Airframe Sprints. Sprints are fixed execution windows that group Tasks and Issues into focused units of work.
+
+> **Related:** [Tasks](../Tasks/Task-Documentation.md) | [Issues](../Issues/Issue-Documentation.md) | [Epics](../Epics/Epic-Documentation.md)
+
+## Organization
+
+- **Sprint-active.md** - The currently active or planning Sprint.
+- **Closed/** - Archived closed Sprints.
+
+## Active Sprint
+
+Currently: **SP-001 Active**
+
+See: [Sprint-active.md](Sprint-active.md)
+
+## All Sprints
+
+Currently: **1 Sprint** | Next available: **SP-002**
+
+| Sprint | Title | Epic | Tasks | Status |
+| ------ | ----- | ---- | ----- | ------ |
+| SP-001 | Agile Airframe Migration Planning and Seed Implementation | EP-001 | T-0081 - T-0088 | Active |
+
+## Statistics
+
+- **Total Sprints:** 1
+- **Closed:** 0
+- **Active:** 1
+- **Review:** 0
+- **Planning:** 0
+- **Backlog:** 0
+- **Next available:** SP-002
+
+---
+
+*Last Updated: 2026-07-06 (SP-001 opened; no Sprint history reconstructed)*

--- a/docs/Sprints/Sprint-active.md
+++ b/docs/Sprints/Sprint-active.md
@@ -1,0 +1,58 @@
+# Active Sprint
+
+Sprints listed here are currently in Planning or Active status and are the current execution focus.
+
+---
+
+## SP-001: Agile Airframe Migration Planning and Seed Implementation
+
+**Status:** Active
+**Epic:** EP-001
+**Goal:** Plan and implement the Agile Airframe documentation migration seed, audit, canonical conversion, GitHub mapping plan, and cutover validation.
+**Start Date:** 2026-07-06
+**End Date:** TBD
+**Capacity:** TBD
+
+### Assigned Tasks
+
+| Task | Title | Priority | Status |
+| ---- | ----- | -------- | ------ |
+| T-0081 | Audit current AR/ER/DR documentation and GitHub issue state | High | Active |
+| T-0082 | Install IrisOS Airframe workspace configuration and canonical planning structure | High | Active |
+| T-0083 | Define separate architecture-record handling for ARs | High | Active |
+| T-0084 | Migrate ER records into Airframe Tasks | Critical | Active |
+| T-0085 | Migrate DR records into Airframe Issues | High | Active |
+| T-0086 | Generate Airframe indexes and GitHub issue mapping | Critical | Active |
+| T-0087 | Prepare approved GitHub issue synchronization migration | High | Active |
+| T-0088 | Validate migration equivalence and document cutover | Critical | Active |
+
+### Assigned Issues
+
+| Issue | Title | Severity | Status |
+| ----- | ----- | -------- | ------ |
+
+### Sprint Notes
+
+- SP-001 is the first IrisOS Airframe Sprint.
+- No historical Sprint records are reconstructed.
+- ARs remain separate architecture records and are not migrated into Epics.
+- GitHub issue mutation is planned but not executed until the migration mapping is reviewed and approved.
+
+### Retrospective
+
+**Completed:**
+- TBD
+
+**Returned to Backlog:**
+- TBD
+
+**What went well:**
+- TBD
+
+**What to improve:**
+- TBD
+
+**Carry-forward notes:**
+- TBD
+
+*Last Updated: 2026-07-06*

--- a/docs/Tasks/Task-Documentation.md
+++ b/docs/Tasks/Task-Documentation.md
@@ -1,0 +1,62 @@
+# Tasks - Index
+
+This is the main index for IrisOS Agile Airframe Tasks. Tasks track planned improvements, documentation changes, migration work, and requirement changes.
+
+> **Note:** For bugs and unintended behavior, see [Issues](../Issues/Issue-Documentation.md).
+> **Related:** [Epics](../Epics/Epic-Documentation.md) | [Sprints](../Sprints/Sprint-Documentation.md)
+
+## Organization
+
+- **Task-backlog.md** - Proposed Tasks not assigned to an active Sprint.
+- **Task-active.md** - Active Tasks assigned to a Sprint.
+- **Task-unverified.md** - Implemented Tasks awaiting System Engineer verification.
+- **Verified/** - Verified Tasks.
+
+## Active Tasks
+
+Currently: **8 active Tasks**
+
+See: [Task-active.md](Task-active.md)
+
+## Backlog Tasks
+
+Currently: **0 backlog Tasks**
+
+See: [Task-backlog.md](Task-backlog.md)
+
+## Unverified Tasks
+
+Currently: **0 unverified Tasks**
+
+See: [Task-unverified.md](Task-unverified.md)
+
+## Verified Tasks
+
+Currently: **0 verified Tasks** | Next available: **T-0089**
+
+## All Tasks
+
+| Task | Title | Epic | Sprint | Priority | Status |
+| ---- | ----- | ---- | ------ | -------- | ------ |
+| T-0081 | Audit current AR/ER/DR documentation and GitHub issue state | EP-001 | SP-001 | High | Active |
+| T-0082 | Install IrisOS Airframe workspace configuration and canonical planning structure | EP-001 | SP-001 | High | Active |
+| T-0083 | Define separate architecture-record handling for ARs | EP-001 | SP-001 | High | Active |
+| T-0084 | Migrate ER records into Airframe Tasks | EP-001 | SP-001 | Critical | Active |
+| T-0085 | Migrate DR records into Airframe Issues | EP-001 | SP-001 | High | Active |
+| T-0086 | Generate Airframe indexes and GitHub issue mapping | EP-001 | SP-001 | Critical | Active |
+| T-0087 | Prepare approved GitHub issue synchronization migration | EP-001 | SP-001 | High | Active |
+| T-0088 | Validate migration equivalence and document cutover | EP-001 | SP-001 | Critical | Active |
+
+## Statistics
+
+- **Total Tasks:** 8
+- **Verified:** 0
+- **Unverified:** 0
+- **Active:** 8
+- **Backlog:** 0
+- **Closed:** 0
+- **Next available:** T-0089
+
+---
+
+*Last Updated: 2026-07-06 (SP-001 migration Tasks created)*

--- a/docs/Tasks/Task-active.md
+++ b/docs/Tasks/Task-active.md
@@ -1,0 +1,208 @@
+# Active Tasks
+
+Tasks listed here are assigned to a Sprint and actively being implemented.
+
+Currently: **8 active Tasks**
+
+---
+
+## T-0081: Audit current AR/ER/DR documentation and GitHub issue state
+
+**Status:** Active
+**GitHub Issue:** TBD
+**Component:** Workflow documentation audit
+**Priority:** High
+**Epic:** EP-001
+**Sprint Assigned:** SP-001
+**Date Requested:** 2026-07-06
+**Date Implemented:** TBD
+**Date Verified:** TBD
+
+**Rationale:**
+The migration must preserve the current manual documentation state and identify local/GitHub drift before any state is rewritten.
+
+**Acceptance Criteria:**
+1. All current AR, ER, and DR documents are inventoried.
+2. Current local status for each AR, ER, and DR is captured.
+3. Current GitHub issue number, title, state, and labels are captured where available.
+4. Local/GitHub mismatches are listed explicitly.
+5. The audit does not mutate GitHub state.
+
+**Evidence:**
+- TBD
+
+## T-0082: Install IrisOS Airframe workspace configuration and canonical planning structure
+
+**Status:** Active
+**GitHub Issue:** TBD
+**Component:** Airframe workspace configuration
+**Priority:** High
+**Epic:** EP-001
+**Sprint Assigned:** SP-001
+**Date Requested:** 2026-07-06
+**Date Implemented:** TBD
+**Date Verified:** TBD
+
+**Rationale:**
+IrisOS needs a repo-local Agile Airframe configuration and canonical planning folders before detailed migration records can be introduced.
+
+**Acceptance Criteria:**
+1. `.airframe/airframe-workspace.json` identifies the IrisOS workspace and `justgus/IrisOS` backend.
+2. `docs/Epics`, `docs/Sprints`, `docs/Tasks`, and `docs/Issues` exist with initial index files.
+3. The active project references `EP-001` and `SP-001`.
+4. Existing manual AR/ER/DR documents remain in place during this seed step.
+
+**Evidence:**
+- TBD
+
+## T-0083: Define separate architecture-record handling for ARs
+
+**Status:** Active
+**GitHub Issue:** TBD
+**Component:** Architecture documentation migration
+**Priority:** High
+**Epic:** EP-001
+**Sprint Assigned:** SP-001
+**Date Requested:** 2026-07-06
+**Date Implemented:** TBD
+**Date Verified:** TBD
+
+**Rationale:**
+The System Engineer directed that ARs remain separate architecture records. The Airframe migration must not treat accepted ARs as delivery Epics.
+
+**Acceptance Criteria:**
+1. The migration defines where architecture records live after cutover.
+2. Existing AR IDs, statuses, GitHub issue references, dependencies, and content are preserved.
+3. Airframe Epics are limited to delivery planning and do not replace ARs.
+4. The master index clearly distinguishes architecture records from Epics.
+
+**Evidence:**
+- TBD
+
+## T-0084: Migrate ER records into Airframe Tasks
+
+**Status:** Active
+**GitHub Issue:** TBD
+**Component:** ER to Task migration
+**Priority:** Critical
+**Epic:** EP-001
+**Sprint Assigned:** SP-001
+**Date Requested:** 2026-07-06
+**Date Implemented:** TBD
+**Date Verified:** TBD
+
+**Rationale:**
+ERs are the current IrisOS implementation work records and should become Airframe Tasks while preserving their existing state.
+
+**Acceptance Criteria:**
+1. Every ER document has exactly one migrated Task record or an explicit migration diagnostic.
+2. Task records preserve source ER ID, title, status, GitHub issue number, dependencies, requirements, acceptance criteria, implementation notes, and verification plan.
+3. Verified ERs are not downgraded.
+4. Proposed ERs remain proposed/backlog unless explicitly assigned to active work.
+5. Task numbering continues from the ER range and does not collide with existing ER IDs.
+
+**Evidence:**
+- TBD
+
+## T-0085: Migrate DR records into Airframe Issues
+
+**Status:** Active
+**GitHub Issue:** TBD
+**Component:** DR to Issue migration
+**Priority:** High
+**Epic:** EP-001
+**Sprint Assigned:** SP-001
+**Date Requested:** 2026-07-06
+**Date Implemented:** TBD
+**Date Verified:** TBD
+
+**Rationale:**
+DRs are defect records and should become Airframe Issues without losing diagnosis or verification context.
+
+**Acceptance Criteria:**
+1. Every DR document has exactly one migrated Issue record or an explicit migration diagnostic.
+2. Issue records preserve source DR ID, title, status, GitHub issue number, severity, priority, environment, reproduction steps, expected behavior, actual behavior, impact, fix plan, and verification plan.
+3. Verified DRs are not downgraded.
+4. The migration distinguishes planned work Tasks from defect Issues.
+
+**Evidence:**
+- TBD
+
+## T-0086: Generate Airframe indexes and GitHub issue mapping
+
+**Status:** Active
+**GitHub Issue:** TBD
+**Component:** Airframe indexes and issue mapping
+**Priority:** Critical
+**Epic:** EP-001
+**Sprint Assigned:** SP-001
+**Date Requested:** 2026-07-06
+**Date Implemented:** TBD
+**Date Verified:** TBD
+
+**Rationale:**
+The migrated records need deterministic indexes and an auditable mapping to existing GitHub issues before GitHub state can be synchronized.
+
+**Acceptance Criteria:**
+1. Task, Issue, Epic, and Sprint indexes reflect the migrated canonical state.
+2. `docs/GitHub-Issue-Mapping.md` maps each migrated Task and Issue to its GitHub issue number where available.
+3. Mapping entries identify source IDs such as `ER-0070` or `DR-0001`.
+4. Known local/GitHub status drift is listed before any mutation.
+5. Index counts match the migrated record counts.
+
+**Evidence:**
+- TBD
+
+## T-0087: Prepare approved GitHub issue synchronization migration
+
+**Status:** Active
+**GitHub Issue:** TBD
+**Component:** GitHub issue synchronization
+**Priority:** High
+**Epic:** EP-001
+**Sprint Assigned:** SP-001
+**Date Requested:** 2026-07-06
+**Date Implemented:** TBD
+**Date Verified:** TBD
+
+**Rationale:**
+GitHub issue titles, bodies, and labels should only be changed after the local migration map is reviewed and approved.
+
+**Acceptance Criteria:**
+1. A GitHub mutation plan identifies all proposed title, body, label, and state changes.
+2. The plan preserves existing issue numbers.
+3. The plan identifies mismatches that need System Engineer approval.
+4. No GitHub mutation is executed as part of this Task without explicit approval.
+5. The migration can be rerun or reviewed without hidden side effects.
+
+**Evidence:**
+- TBD
+
+## T-0088: Validate migration equivalence and document cutover
+
+**Status:** Active
+**GitHub Issue:** TBD
+**Component:** Migration validation and cutover
+**Priority:** Critical
+**Epic:** EP-001
+**Sprint Assigned:** SP-001
+**Date Requested:** 2026-07-06
+**Date Implemented:** TBD
+**Date Verified:** TBD
+
+**Rationale:**
+The migration should not be considered complete until the new canonical documentation is shown to represent the same state as the current manual documentation.
+
+**Acceptance Criteria:**
+1. Every source AR, ER, and DR is accounted for in the migrated state or diagnostics.
+2. Status counts match the approved source of truth.
+3. Legacy manual docs are either preserved or marked legacy according to the approved cutover path.
+4. Build and documentation validation commands are recorded.
+5. Residual risks and follow-up Tasks are documented before EP-001 closeout.
+
+**Evidence:**
+- TBD
+
+---
+
+*Last Updated: 2026-07-06*

--- a/docs/Tasks/Task-backlog.md
+++ b/docs/Tasks/Task-backlog.md
@@ -1,0 +1,9 @@
+# Task Backlog
+
+Tasks listed here are proposed and not assigned to an active Sprint.
+
+Currently: **0 backlog Tasks**
+
+---
+
+*Last Updated: 2026-07-06*

--- a/docs/Tasks/Task-unverified.md
+++ b/docs/Tasks/Task-unverified.md
@@ -1,0 +1,9 @@
+# Unverified Tasks
+
+Tasks listed here are implemented and awaiting System Engineer verification.
+
+Currently: **0 unverified Tasks**
+
+---
+
+*Last Updated: 2026-07-06*


### PR DESCRIPTION
## Summary
- add IrisOS Airframe workspace configuration targeting justgus/IrisOS
- create EP-001 and SP-001 for the Agile Airframe migration effort
- create T-0081 through T-0088, extending from the current ER-0080 range, to cover audit, configuration, AR handling, ER/DR migration, GitHub mapping, synchronization planning, and cutover validation

## Scope notes
- ARs remain separate architecture records and are not converted into Epics
- no historical Sprint records are reconstructed
- GitHub issue fields remain TBD until the migration mapping and mutation plan are reviewed and approved

## Validation
- git diff --cached --check
- rg -n "[–—✅🟡🔵🔴🟠]" .airframe docs/Epics docs/Sprints docs/Tasks docs/Issues
- ./configure could not be run because this checkout does not currently contain a generated configure script
- bootstrap.sh was not run because this docs-only planning change should not regenerate Autotools outputs